### PR TITLE
feat: smart cross-platform login & zero-config onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,34 +161,34 @@ Manual token usage, debug-session auth, and programmatic Node.js usage are cover
 
 ## Platform support
 
-| Feature                | macOS          | Windows / Linux |
-| ---------------------- | -------------- | --------------- |
-| **Interactive login**  | Full support   | Full support    |
-| **Auto-login (FIDO2)** | Full support   | Not supported   |
-| **Debug session**      | Full support   | Full support    |
-| **Direct token**       | Full support   | Full support    |
-| **Token caching**      | macOS Keychain | Not available   |
-| **CLI & MCP server**   | Full support   | Full support    |
-| **Programmatic API**   | Full support   | Full support    |
+| Feature                | macOS          | Windows              | Linux                                   |
+| ---------------------- | -------------- | -------------------- | --------------------------------------- |
+| **Smart login**        | Full support   | Full support         | Full support                            |
+| **Interactive login**  | Full support   | Full support         | Full support                            |
+| **Auto-login (FIDO2)** | Full support   | Not supported        | Not supported                           |
+| **Debug session**      | Full support   | Full support         | Full support                            |
+| **Direct token**       | Full support   | Full support         | Full support                            |
+| **Token caching**      | macOS Keychain | DPAPI-encrypted file | `secret-tool` (libsecret) or plain file |
+| **CLI & MCP server**   | Full support   | Full support         | Full support                            |
+| **Programmatic API**   | Full support   | Full support         | Full support                            |
 
 ## Authentication
 
 Most users do not need to manage tokens manually.
 
-If you use interactive login, auto-login, or a Chrome debug session, `teams-api` captures the full token bundle automatically from Teams web traffic. That includes the base `skypeToken` plus the extra bearer tokens used for profile resolution and reliable people/chat/channel search.
+**Smart login (default)**: With no configuration, `teams-api` uses smart login — it automatically picks the best strategy for your platform. On macOS with Chrome and a FIDO2 passkey, it tries auto-login first; on all platforms, it falls back to interactive browser login. Tokens are cached in the platform credential store (Keychain on macOS, DPAPI on Windows, secret-tool/file on Linux) and reused for up to 23 hours.
 
-Those flows also detect the Teams chat region automatically from the intercepted request URLs, so most users do not need to set `--region` or `TEAMS_REGION`.
-
-On macOS, prefer auto-login when you have a platform authenticator / FIDO2 passkey set up. On other platforms, use interactive login.
+All login flows capture the full token bundle automatically from Teams web traffic. That includes the base `skypeToken` plus the extra bearer tokens used for profile resolution and reliable people/chat/channel search. Region is auto-detected from the intercepted request URLs.
 
 Direct token usage is the advanced/manual path.
 
-| Method                | Description                                                                  | Automation       | Platform |
-| --------------------- | ---------------------------------------------------------------------------- | ---------------- | -------- |
-| **Auto-login**        | Playwright launches system Chrome and captures the full token bundle         | Fully unattended | macOS    |
-| **Interactive login** | Opens a browser window and captures skype, middle-tier, and Substrate tokens | One-time manual  | All      |
-| **Debug session**     | Connects to a running Chrome instance and captures the full token bundle     | Semi-manual      | All      |
-| **Direct token**      | Provide a previously captured token or token bundle explicitly               | Manual           | All      |
+| Method                | Description                                                                          | Automation       | Platform |
+| --------------------- | ------------------------------------------------------------------------------------ | ---------------- | -------- |
+| **Smart login**       | Auto-detects the best strategy; tries auto-login on macOS, falls back to interactive | Automatic        | All      |
+| **Auto-login**        | Playwright launches system Chrome and captures the full token bundle                 | Fully unattended | macOS    |
+| **Interactive login** | Opens a browser window and captures skype, middle-tier, and Substrate tokens         | One-time manual  | All      |
+| **Debug session**     | Connects to a running Chrome instance and captures the full token bundle             | Semi-manual      | All      |
+| **Direct token**      | Provide a previously captured token or token bundle explicitly                       | Manual           | All      |
 
 ### Auto-login (macOS only)
 
@@ -261,18 +261,20 @@ The examples below use `teams-api` for readability. If you are not installing gl
 
 ### Auth flags (available on all commands)
 
-| Flag                        | Description                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------- |
-| `--login`                   | Interactive browser login (all platforms)                                        |
-| `--auto`                    | Auto-acquire token via FIDO2 passkey (macOS)                                     |
-| `--email <email>`           | Corporate email (required with `--auto`, optional otherwise)                     |
-| `--token <token>`           | Use an existing skype token (advanced/manual)                                    |
-| `--bearer-token <token>`    | Optional middle-tier bearer token (advanced/manual)                              |
-| `--substrate-token <token>` | Optional Substrate bearer token (advanced/manual)                                |
-| `--debug-port <port>`       | Chrome debug port (default: 9222)                                                |
-| `--region <region>`         | API region override. Auto-detected for login/debug auth; required with `--token` |
-| `--format <format>`         | Output format: json, text, md, toon                                              |
-| `--output <file>`           | Export output to file (default format: md)                                       |
+| Flag                        | Description                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| _(none)_                    | **Default**: Smart login — auto-login on macOS if possible, interactive otherwise |
+| `--login`                   | Force interactive browser login (all platforms)                                   |
+| `--auto`                    | Force auto-acquire token via FIDO2 passkey (macOS)                                |
+| `--debug`                   | Connect to a running Chrome debug session                                         |
+| `--email <email>`           | Corporate email (required with `--auto`, optional otherwise)                      |
+| `--token <token>`           | Use an existing skype token (advanced/manual)                                     |
+| `--bearer-token <token>`    | Optional middle-tier bearer token (advanced/manual)                               |
+| `--substrate-token <token>` | Optional Substrate bearer token (advanced/manual)                                 |
+| `--debug-port <port>`       | Chrome debug port for `--debug` (default: 9222)                                   |
+| `--region <region>`         | API region override. Auto-detected for login/debug auth; required with `--token`  |
+| `--format <format>`         | Output format: json, text, md, toon                                               |
+| `--output <file>`           | Export output to file (default format: md)                                        |
 
 ### Examples
 
@@ -350,16 +352,17 @@ Use this only if you already have tokens from another flow or need to avoid brow
 
 ### Environment variables
 
-| Variable                | Description                                                           |
-| ----------------------- | --------------------------------------------------------------------- |
-| `TEAMS_TOKEN`           | Pre-existing skype token                                              |
-| `TEAMS_BEARER_TOKEN`    | Optional middle-tier bearer token                                     |
-| `TEAMS_SUBSTRATE_TOKEN` | Optional Substrate bearer token                                       |
-| `TEAMS_REGION`          | API region override. Required with `TEAMS_TOKEN`; optional otherwise  |
-| `TEAMS_EMAIL`           | Corporate email. Optional — the server prompts the AI agent if needed |
-| `TEAMS_AUTO`            | Set to `true` to enable auto-login (macOS + FIDO2)                    |
-| `TEAMS_LOGIN`           | Set to `true` to enable interactive browser login                     |
-| `TEAMS_DEBUG_PORT`      | Chrome debug port (default: 9222)                                     |
+| Variable                | Description                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `TEAMS_TOKEN`           | Pre-existing skype token                                                       |
+| `TEAMS_BEARER_TOKEN`    | Optional middle-tier bearer token                                              |
+| `TEAMS_SUBSTRATE_TOKEN` | Optional Substrate bearer token                                                |
+| `TEAMS_REGION`          | API region override. Required with `TEAMS_TOKEN`; optional otherwise           |
+| `TEAMS_EMAIL`           | Corporate email. Optional — enables token caching and auto-login on macOS      |
+| `TEAMS_AUTO`            | Set to `true` to force auto-login (macOS + FIDO2)                              |
+| `TEAMS_LOGIN`           | Set to `true` to force interactive browser login                               |
+| `TEAMS_DEBUG`           | Set to `true` to use Chrome debug session (requires `--remote-debugging-port`) |
+| `TEAMS_DEBUG_PORT`      | Chrome debug port (default: 9222)                                              |
 
 ### Available tools
 
@@ -395,7 +398,7 @@ The Teams Chat Service URL varies by region. Login-based and debug-session auth 
 - Token lifetime is ~24 hours. After expiry, you must re-acquire.
 - The Teams Chat Service REST API is undocumented and may change without notice.
 - Auto-login requires macOS, system Chrome, a platform authenticator, and a FIDO2 passkey. On other platforms, use interactive login (`--login`) instead.
-- Token caching (macOS Keychain) is only available on macOS. On other platforms, pass the token directly or re-run interactive login each time.
+- Token caching uses the platform credential store: macOS Keychain, Windows DPAPI, or Linux `secret-tool`/file. On Linux without `secret-tool`, tokens are stored in a plain file at `~/.config/teams-api/` with `0o600` permissions.
 - The members API returns empty display names for 1:1 chat participants. Use `findOneOnOneConversation()` to resolve names from message history.
 - Reaction actor identities come from the `emotions` field in message payloads. Parsing handles both JSON-string and array formats.
 
@@ -414,15 +417,19 @@ Example:
 ```typescript
 import { TeamsClient } from "teams-api";
 
-// Interactive login — opens a browser, you log in manually (all platforms)
-const client = await TeamsClient.fromInteractiveLogin();
+// Smart login (recommended) — auto-detects the best strategy for your platform
+const client = await TeamsClient.connect();
 
-// Or auto-login via platform authenticator (macOS + FIDO2 passkey)
-const autoClient = await TeamsClient.fromAutoLogin({
+// With email — enables token caching and auto-login on macOS
+const cachedClient = await TeamsClient.connect({
   email: "you@example.com",
 });
 
-// Advanced/manual: create a client from previously captured tokens
+// Or explicit strategies:
+const interactiveClient = await TeamsClient.fromInteractiveLogin();
+const autoClient = await TeamsClient.fromAutoLogin({
+  email: "you@example.com",
+});
 const manualClient = TeamsClient.fromToken("skype-token-here", "emea");
 
 const conversations = await client.listConversations();

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ teams-api auth --login --email you@example.com
 ```
 
 > [!NOTE]
-> Interactive login uses Playwright's bundled Chromium. No system Chrome installation is required.
+> Interactive login prefers an installed Microsoft Edge / Google Chrome when available. If neither is available, `teams-api` installs Playwright Chromium automatically on first use. That first login may take a minute while the browser runtime downloads.
 
 ### Advanced / manual methods
 

--- a/server.json
+++ b/server.json
@@ -38,7 +38,13 @@
         },
         {
           "name": "TEAMS_LOGIN",
-          "description": "Set to \"true\" to use interactive browser login (all platforms)",
+          "description": "Set to \"true\" to force interactive browser login (all platforms)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "TEAMS_DEBUG",
+          "description": "Set to \"true\" to use Chrome debug session",
           "isRequired": false,
           "isSecret": false
         },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,6 +18,7 @@ import type {
   InteractiveLoginOptions,
   ManualTokenOptions,
 } from "./types.js";
+import { launchInteractiveBrowser } from "./browser-runtime.js";
 import { detectTeamsRegionFromUrl, resolveTeamsRegion } from "./region.js";
 
 const TEAMS_URL = "https://teams.cloud.microsoft/";
@@ -435,7 +436,7 @@ const INTERACTIVE_LOGIN_TIMEOUT = 5 * 60 * 1_000;
 /**
  * Acquire a Teams skype token via interactive browser login.
  *
- * Opens a visible Chromium window (Playwright's bundled browser),
+ * Opens a visible Chromium-based browser window,
  * navigates to Teams, and waits for the user to complete login
  * manually. Once Teams loads, the skype token is captured via
  * CDP Fetch interception.
@@ -452,7 +453,7 @@ export async function acquireTokenViaInteractiveLogin(
     : () => {};
 
   log("Launching browser for interactive login...");
-  const browser = await chromium.launch({ headless: false });
+  const browser = await launchInteractiveBrowser(chromium, log);
   const context = await browser.newContext();
   const page = await context.newPage();
 

--- a/src/browser-runtime.ts
+++ b/src/browser-runtime.ts
@@ -1,0 +1,132 @@
+/**
+ * Browser runtime helpers for interactive login.
+ *
+ * Interactive login depends on Chromium DevTools Protocol interception,
+ * so we prefer installed Chromium-based browsers (Edge/Chrome) and
+ * fall back to Playwright's bundled Chromium when needed.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import type { Browser } from "playwright";
+
+const requireFromHere = createRequire(__filename);
+
+type LogFunction = (...arguments_: unknown[]) => void;
+type InteractiveBrowserChannel = "chrome" | "msedge";
+
+export interface ChromiumBrowserLauncher {
+  launch(options: {
+    headless: false;
+    channel?: InteractiveBrowserChannel;
+  }): Promise<Browser>;
+}
+
+const INTERACTIVE_BROWSER_CHANNELS: Partial<
+  Record<NodeJS.Platform, InteractiveBrowserChannel[]>
+> = {
+  darwin: ["chrome"],
+  win32: ["msedge", "chrome"],
+  linux: ["chrome", "msedge"],
+};
+
+function formatChannelName(channel: InteractiveBrowserChannel): string {
+  switch (channel) {
+    case "msedge":
+      return "Microsoft Edge";
+    case "chrome":
+      return "Google Chrome";
+  }
+}
+
+export function getInteractiveBrowserChannels(
+  platform: NodeJS.Platform = process.platform,
+): InteractiveBrowserChannel[] {
+  return INTERACTIVE_BROWSER_CHANNELS[platform] ?? ["chrome", "msedge"];
+}
+
+export function isMissingPlaywrightBrowserError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes("Executable doesn't exist")
+  );
+}
+
+export function installBundledChromium(log: LogFunction): void {
+  const playwrightPackageJson = requireFromHere.resolve(
+    "playwright/package.json",
+  );
+  const playwrightCliPath = join(dirname(playwrightPackageJson), "cli.js");
+
+  log(
+    "Playwright Chromium is not installed. Downloading it now (one-time setup)...",
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [playwrightCliPath, "install", "chromium"],
+    {
+      encoding: "utf-8",
+    },
+  );
+
+  if (result.status === 0) {
+    log("Playwright Chromium installed successfully.");
+    return;
+  }
+
+  const detail =
+    result.error?.message ||
+    result.stderr?.trim() ||
+    result.stdout?.trim() ||
+    "Unknown error";
+
+  throw new Error(
+    `Failed to install Playwright Chromium automatically. ${detail}`,
+  );
+}
+
+export async function launchInteractiveBrowser(
+  chromium: ChromiumBrowserLauncher,
+  log: LogFunction,
+  options?: {
+    platform?: NodeJS.Platform;
+    installBundledChromium?: (log: LogFunction) => void;
+  },
+): Promise<Browser> {
+  for (const channel of getInteractiveBrowserChannels(options?.platform)) {
+    try {
+      log(`Trying installed ${formatChannelName(channel)}...`);
+      const browser = await chromium.launch({
+        headless: false,
+        channel,
+      });
+      log(
+        `Using installed ${formatChannelName(channel)} for interactive login.`,
+      );
+      return browser;
+    } catch (error) {
+      log(
+        `Could not launch ${formatChannelName(channel)}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  try {
+    log("Trying Playwright bundled Chromium...");
+    const browser = await chromium.launch({ headless: false });
+    log("Using Playwright bundled Chromium for interactive login.");
+    return browser;
+  } catch (error) {
+    if (!isMissingPlaywrightBrowserError(error)) {
+      throw error;
+    }
+
+    const installChromium =
+      options?.installBundledChromium ?? installBundledChromium;
+    installChromium(log);
+
+    log("Retrying Playwright bundled Chromium after install...");
+    return chromium.launch({ headless: false });
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,10 @@
  *
  * Special commands (auth, logout) are defined here directly since
  * they handle authentication rather than Teams data operations.
+ *
+ * Default auth: Smart login (auto-login on macOS if prerequisites met,
+ * interactive browser login otherwise). Use --auto, --login, --debug,
+ * or --token for explicit auth strategies.
  */
 
 import { writeFileSync } from "node:fs";
@@ -36,6 +40,7 @@ program
 interface AuthFlags {
   auto?: boolean;
   login?: boolean;
+  debug?: boolean;
   email?: string;
   token?: string;
   bearerToken?: string;
@@ -51,9 +56,10 @@ function addAuthOptions(command: Command): Command {
       "--login",
       "Interactive browser login (all platforms, no FIDO2 needed)",
     )
+    .option("--debug", "Connect to a running Chrome debug session")
     .option(
       "--email <email>",
-      "Corporate email (required with --auto, optional with --login)",
+      "Corporate email (required with --auto, optional otherwise)",
     )
     .option("--token <token>", "Use an existing skype token directly")
     .option(
@@ -66,7 +72,7 @@ function addAuthOptions(command: Command): Command {
     )
     .option(
       "--debug-port <port>",
-      "Chrome debug port for manual token capture",
+      "Chrome debug port for debug session",
       "9222",
     )
     .option(
@@ -112,11 +118,20 @@ async function createClient(flags: AuthFlags): Promise<TeamsClient> {
     return TeamsClient.fromInteractiveLogin(interactiveLoginOptions);
   }
 
-  const manualOptions: ManualTokenOptions = {
-    debugPort: Number(flags.debugPort),
+  if (flags.debug) {
+    const manualOptions: ManualTokenOptions = {
+      debugPort: Number(flags.debugPort),
+      region: flags.region,
+    };
+    return TeamsClient.fromDebugSession(manualOptions);
+  }
+
+  // Default: smart login (zero-config)
+  return TeamsClient.connect({
+    email: flags.email,
     region: flags.region,
-  };
-  return TeamsClient.fromDebugSession(manualOptions);
+    verbose: true,
+  });
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -253,7 +268,7 @@ addAuthOptions(
 
 program
   .command("logout")
-  .description("Clear cached token from the macOS Keychain")
+  .description("Clear cached token from the credential store")
   .requiredOption("--email <email>", "Email whose cached token to clear")
   .action((flags: { email: string }) => {
     TeamsClient.clearCachedToken(flags.email);

--- a/src/credential-store.ts
+++ b/src/credential-store.ts
@@ -1,0 +1,292 @@
+/**
+ * Cross-platform credential storage.
+ *
+ * Provides a unified interface for securely storing and retrieving
+ * credentials across macOS, Windows, and Linux.
+ *
+ * | Platform | Mechanism                                              |
+ * |----------|--------------------------------------------------------|
+ * | macOS    | System Keychain via `security` CLI                     |
+ * | Windows  | DPAPI encryption → file in %APPDATA%/teams-api/        |
+ * | Linux    | `secret-tool` (libsecret) if available, else file with |
+ * |          | 0o600 perms at ~/.config/teams-api/                    |
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+export interface CredentialStore {
+  save(account: string, data: string): void;
+  load(account: string): string | null;
+  clear(account: string): void;
+}
+
+// ── macOS: System Keychain ────────────────────────────────────────────
+
+const KEYCHAIN_SERVICE = "teams-api";
+
+class KeychainStore implements CredentialStore {
+  save(account: string, data: string): void {
+    execFileSync("security", [
+      "add-generic-password",
+      "-a",
+      account,
+      "-s",
+      KEYCHAIN_SERVICE,
+      "-w",
+      data,
+      "-U",
+    ]);
+  }
+
+  load(account: string): string | null {
+    try {
+      return execFileSync(
+        "security",
+        ["find-generic-password", "-a", account, "-s", KEYCHAIN_SERVICE, "-w"],
+        { encoding: "utf-8" },
+      ).trim();
+    } catch {
+      return null;
+    }
+  }
+
+  clear(account: string): void {
+    try {
+      execFileSync("security", [
+        "delete-generic-password",
+        "-a",
+        account,
+        "-s",
+        KEYCHAIN_SERVICE,
+      ]);
+    } catch {
+      // Entry may not exist, that's fine
+    }
+  }
+}
+
+// ── Windows: DPAPI encryption → file ─────────────────────────────────
+
+function getWindowsStorePath(): string {
+  const appData =
+    process.env.APPDATA ??
+    join(process.env.USERPROFILE ?? "", "AppData", "Roaming");
+  return join(appData, "teams-api");
+}
+
+function accountToFileName(account: string): string {
+  return createHash("sha256").update(account).digest("hex") + ".dat";
+}
+
+class WinCredStore implements CredentialStore {
+  private getFilePath(account: string): string {
+    const dir = getWindowsStorePath();
+    return join(dir, accountToFileName(account));
+  }
+
+  private ensureDir(): void {
+    const dir = getWindowsStorePath();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  save(account: string, data: string): void {
+    this.ensureDir();
+    const base64Input = Buffer.from(data, "utf-8").toString("base64");
+
+    // Use DPAPI to encrypt data tied to the current Windows user account
+    const encrypted = execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        `Add-Type -AssemblyName System.Security; ` +
+          `$bytes = [System.Convert]::FromBase64String('${base64Input}'); ` +
+          `$encrypted = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); ` +
+          `[System.Convert]::ToBase64String($encrypted)`,
+      ],
+      { encoding: "utf-8" },
+    ).trim();
+
+    writeFileSync(this.getFilePath(account), encrypted, { encoding: "utf-8" });
+  }
+
+  load(account: string): string | null {
+    const filePath = this.getFilePath(account);
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    try {
+      const encrypted = readFileSync(filePath, { encoding: "utf-8" }).trim();
+
+      const decrypted = execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          `Add-Type -AssemblyName System.Security; ` +
+            `$encrypted = [System.Convert]::FromBase64String('${encrypted}'); ` +
+            `$bytes = [System.Security.Cryptography.ProtectedData]::Unprotect($encrypted, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser); ` +
+            `[System.Text.Encoding]::UTF8.GetString($bytes)`,
+        ],
+        { encoding: "utf-8" },
+      ).trim();
+
+      return decrypted;
+    } catch {
+      // Encrypted data may be corrupted or from a different user
+      this.clear(account);
+      return null;
+    }
+  }
+
+  clear(account: string): void {
+    const filePath = this.getFilePath(account);
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // File may not exist, that's fine
+    }
+  }
+}
+
+// ── Linux: secret-tool or file-based fallback ────────────────────────
+
+function getLinuxStorePath(): string {
+  const configDir =
+    process.env.XDG_CONFIG_HOME ?? join(process.env.HOME ?? "", ".config");
+  return join(configDir, "teams-api");
+}
+
+function hasSecretTool(): boolean {
+  try {
+    execFileSync("which", ["secret-tool"], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+class LinuxStore implements CredentialStore {
+  private useSecretTool: boolean;
+
+  constructor() {
+    this.useSecretTool = hasSecretTool();
+  }
+
+  private getFilePath(account: string): string {
+    const dir = getLinuxStorePath();
+    return join(dir, accountToFileName(account));
+  }
+
+  private ensureDir(): void {
+    const dir = getLinuxStorePath();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  save(account: string, data: string): void {
+    if (this.useSecretTool) {
+      try {
+        execFileSync(
+          "secret-tool",
+          [
+            "store",
+            "--label",
+            "teams-api",
+            "service",
+            KEYCHAIN_SERVICE,
+            "account",
+            account,
+          ],
+          { input: data, encoding: "utf-8" },
+        );
+        return;
+      } catch {
+        // Fall through to file-based storage
+        this.useSecretTool = false;
+      }
+    }
+
+    this.ensureDir();
+    writeFileSync(this.getFilePath(account), data, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+  }
+
+  load(account: string): string | null {
+    if (this.useSecretTool) {
+      try {
+        return execFileSync(
+          "secret-tool",
+          ["lookup", "service", KEYCHAIN_SERVICE, "account", account],
+          { encoding: "utf-8" },
+        ).trim();
+      } catch {
+        // Secret not found or secret-tool failed
+        return null;
+      }
+    }
+
+    const filePath = this.getFilePath(account);
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    try {
+      return readFileSync(filePath, { encoding: "utf-8" }).trim();
+    } catch {
+      return null;
+    }
+  }
+
+  clear(account: string): void {
+    if (this.useSecretTool) {
+      try {
+        execFileSync("secret-tool", [
+          "clear",
+          "service",
+          KEYCHAIN_SERVICE,
+          "account",
+          account,
+        ]);
+      } catch {
+        // Entry may not exist
+      }
+    }
+
+    // Also clean up the file-based fallback
+    const filePath = this.getFilePath(account);
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // File may not exist
+    }
+  }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────
+
+export function createCredentialStore(): CredentialStore {
+  switch (process.platform) {
+    case "darwin":
+      return new KeychainStore();
+    case "win32":
+      return new WinCredStore();
+    default:
+      return new LinuxStore();
+  }
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -12,10 +12,14 @@
  *     TEAMS_BEARER_TOKEN    — Optional middle-tier bearer token for profile resolution
  *     TEAMS_SUBSTRATE_TOKEN — Optional Substrate bearer token for people/chat search
  *     TEAMS_REGION          — API region (required with TEAMS_TOKEN, optional otherwise)
- *     TEAMS_EMAIL           — Corporate email (optional; the server prompts the AI agent if needed)
+ *     TEAMS_EMAIL           — Corporate email (optional; enables token caching and auto-login on macOS)
  *     TEAMS_AUTO            — Set to "true" to use auto-login (macOS + FIDO2)
  *     TEAMS_LOGIN           — Set to "true" to use interactive browser login (all platforms)
+ *     TEAMS_DEBUG           — Set to "true" to use Chrome debug session (requires Chrome with --remote-debugging-port)
  *     TEAMS_DEBUG_PORT      — Chrome debug port (default: 9222)
+ *
+ * Default (no env vars): Smart login — tries auto-login on macOS if Chrome + email
+ * are available, falls back to interactive browser login on all platforms.
  *
  * Usage in VS Code settings (mcp config):
  *   {
@@ -23,9 +27,7 @@
  *       "teams": {
  *         "command": "npx",
  *         "args": ["-y", "teams-api"],
- *         "env": {
- *           "TEAMS_LOGIN": "true"
- *         }
+ *         "env": {}
  *       }
  *     }
  *   }
@@ -62,6 +64,7 @@ async function getClient(toolEmail?: string): Promise<TeamsClient> {
   const email = process.env.TEAMS_EMAIL || toolEmail;
   const envAuto = process.env.TEAMS_AUTO === "true";
   const envLogin = process.env.TEAMS_LOGIN === "true";
+  const envDebug = process.env.TEAMS_DEBUG === "true";
   const envDebugPort = process.env.TEAMS_DEBUG_PORT
     ? Number(process.env.TEAMS_DEBUG_PORT)
     : 9222;
@@ -92,10 +95,17 @@ async function getClient(toolEmail?: string): Promise<TeamsClient> {
       email,
       verbose: false,
     });
-  } else {
+  } else if (envDebug) {
     clientInstance = await TeamsClient.fromDebugSession({
       debugPort: envDebugPort,
       region: envRegion,
+    });
+  } else {
+    // Default: smart login (zero-config)
+    clientInstance = await TeamsClient.connect({
+      email,
+      region: envRegion,
+      verbose: false,
     });
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,45 @@
+/**
+ * Platform detection utilities for smart login flow.
+ *
+ * Determines the current platform and whether auto-login prerequisites
+ * are met (macOS + system Chrome installed).
+ */
+
+import { accessSync, constants } from "node:fs";
+
+const DEFAULT_SYSTEM_CHROME_PATH =
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+export type Platform = "macos" | "windows" | "linux";
+
+export function detectPlatform(): Platform {
+  switch (process.platform) {
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "windows";
+    default:
+      return "linux";
+  }
+}
+
+/**
+ * Check whether auto-login prerequisites are met:
+ * macOS + system Chrome exists at the expected path.
+ *
+ * Does NOT check for FIDO2 passkey enrollment — auto-login will
+ * simply fail and the smart login flow will fall back to interactive.
+ */
+export function canAttemptAutoLogin(chromePath?: string): boolean {
+  if (detectPlatform() !== "macos") {
+    return false;
+  }
+
+  const chromeExecutable = chromePath ?? DEFAULT_SYSTEM_CHROME_PATH;
+  try {
+    accessSync(chromeExecutable, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/smart-login.ts
+++ b/src/smart-login.ts
@@ -1,0 +1,52 @@
+/**
+ * Smart login — the zero-config default authentication strategy.
+ *
+ * Strategy:
+ *   1. If on macOS + email provided + system Chrome exists → try auto-login
+ *   2. If auto-login fails or prerequisites not met → interactive login
+ *
+ * Auto-login errors are caught and logged, then we immediately fall back
+ * to interactive. Only if interactive also fails does the user see an error.
+ */
+
+import type { TeamsToken, SmartLoginOptions } from "./types.js";
+import { canAttemptAutoLogin } from "./platform.js";
+import {
+  acquireTokenViaAutoLogin,
+  acquireTokenViaInteractiveLogin,
+} from "./auth.js";
+
+type LogFunction = (...arguments_: unknown[]) => void;
+
+export async function acquireTokenViaSmartLogin(
+  options?: SmartLoginOptions,
+): Promise<TeamsToken> {
+  const log: LogFunction = options?.verbose
+    ? console.error.bind(console)
+    : () => {};
+
+  // Try auto-login if prerequisites are met
+  if (options?.email && canAttemptAutoLogin()) {
+    log("Auto-login prerequisites met (macOS + Chrome), attempting...");
+    try {
+      return await acquireTokenViaAutoLogin({
+        email: options.email,
+        region: options.region,
+        headless: true,
+        verbose: options.verbose,
+      });
+    } catch (error) {
+      log(
+        `Auto-login failed: ${(error as Error).message}. Falling back to interactive login...`,
+      );
+    }
+  }
+
+  // Fall back to interactive login (works everywhere)
+  log("Using interactive browser login...");
+  return acquireTokenViaInteractiveLogin({
+    region: options?.region,
+    email: options?.email,
+    verbose: options?.verbose,
+  });
+}

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -35,6 +35,7 @@ import type {
   AutoLoginOptions,
   InteractiveLoginOptions,
   ManualTokenOptions,
+  SmartLoginOptions,
   Conversation,
   Message,
   MessageFormat,
@@ -67,6 +68,7 @@ import {
   acquireTokenViaInteractiveLogin,
   acquireTokenViaDebugSession,
 } from "./auth.js";
+import { acquireTokenViaSmartLogin } from "./smart-login.js";
 import { DEFAULT_TEAMS_REGION, resolveTeamsRegion } from "./region.js";
 import { saveToken, loadToken, clearToken } from "./token-store.js";
 
@@ -75,11 +77,13 @@ export {
   acquireTokenViaInteractiveLogin,
   acquireTokenViaDebugSession,
 } from "./auth.js";
+export { acquireTokenViaSmartLogin } from "./smart-login.js";
 export type {
   TeamsToken,
   AutoLoginOptions,
   InteractiveLoginOptions,
   ManualTokenOptions,
+  SmartLoginOptions,
   Conversation,
   Message,
   MessageFormat,
@@ -145,6 +149,7 @@ function extractMriSuffix(senderMri: string): string {
 export class TeamsClient {
   private token: TeamsToken;
   private autoLoginOptions: AutoLoginOptions | null = null;
+  private smartLoginOptions: SmartLoginOptions | null = null;
   private cachedDisplayName: string | null = null;
 
   private constructor(token: TeamsToken) {
@@ -191,6 +196,56 @@ export class TeamsClient {
 
     const client = new TeamsClient(token);
     client.autoLoginOptions = options;
+    return client;
+  }
+
+  /**
+   * Smart login — the zero-config default entry point.
+   *
+   * This is the recommended entry point for new users. It:
+   *   1. If email provided, checks the credential store for a cached token
+   *   2. Acquires a fresh token via smart login (auto-login on macOS if
+   *      prerequisites met, interactive login otherwise)
+   *   3. Caches the token if email is available
+   *   4. Automatically re-acquires the token if a 401 occurs mid-session
+   *
+   * No environment variables or platform-specific flags are needed.
+   */
+  static async connect(options?: SmartLoginOptions): Promise<TeamsClient> {
+    const log = options?.verbose ? console.error.bind(console) : () => {};
+
+    // Check credential store for cached token (requires email)
+    if (options?.email) {
+      const cachedToken = loadToken(options.email);
+      if (cachedToken) {
+        const region = resolveTeamsRegion(options.region, cachedToken.region);
+        const token =
+          region === cachedToken.region
+            ? cachedToken
+            : { ...cachedToken, region };
+
+        log("Using cached token from credential store");
+        if (token !== cachedToken) {
+          log(`Overriding cached region with explicit value: ${region}`);
+          saveToken(options.email, token);
+        }
+
+        const client = new TeamsClient(token);
+        client.smartLoginOptions = options;
+        return client;
+      }
+    }
+
+    log("No cached token found, acquiring via smart login...");
+    const token = await acquireTokenViaSmartLogin(options);
+
+    if (options?.email) {
+      saveToken(options.email, token);
+      log("Token saved to credential store");
+    }
+
+    const client = new TeamsClient(token);
+    client.smartLoginOptions = options ?? {};
     return client;
   }
 
@@ -250,9 +305,9 @@ export class TeamsClient {
   }
 
   /**
-   * Clear a cached token from the macOS Keychain.
+   * Clear a cached token from the credential store.
    *
-   * Use this to force a fresh login on the next `create()` call.
+   * Use this to force a fresh login on the next `create()` or `connect()` call.
    */
   static clearCachedToken(email: string): void {
     clearToken(email);
@@ -713,13 +768,29 @@ export class TeamsClient {
   }
 
   /**
-   * Re-acquire the token via auto-login and update the cached version.
+   * Re-acquire the token and update the cached version.
    *
    * Called automatically by `withTokenRefresh` on 401 errors.
+   * Supports both auto-login (create()) and smart login (connect()) paths.
    */
   private async refreshToken(): Promise<void> {
+    if (this.smartLoginOptions) {
+      if (this.smartLoginOptions.email) {
+        clearToken(this.smartLoginOptions.email);
+      }
+      const freshToken = await acquireTokenViaSmartLogin(
+        this.smartLoginOptions,
+      );
+      if (this.smartLoginOptions.email) {
+        saveToken(this.smartLoginOptions.email, freshToken);
+      }
+      this.token = freshToken;
+      this.cachedDisplayName = null;
+      return;
+    }
+
     if (!this.autoLoginOptions) {
-      throw new Error("Cannot refresh token: no auto-login options configured");
+      throw new Error("Cannot refresh token: no login options configured");
     }
 
     clearToken(this.autoLoginOptions.email);
@@ -740,7 +811,10 @@ export class TeamsClient {
     try {
       return await operation();
     } catch (error) {
-      if (error instanceof ApiAuthError && this.autoLoginOptions) {
+      if (
+        error instanceof ApiAuthError &&
+        (this.autoLoginOptions || this.smartLoginOptions)
+      ) {
         await this.refreshToken();
         return await operation();
       }

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,17 +1,15 @@
 /**
- * Secure token persistence using the macOS Keychain.
+ * Secure token persistence using the platform credential store.
  *
- * Stores Teams tokens in the system Keychain via the `security` CLI tool.
+ * Stores Teams tokens via the cross-platform credential store:
+ * macOS Keychain, Windows DPAPI, or Linux secret-tool/file.
  * Tokens are base64-encoded JSON with an acquisition timestamp.
  * Expired tokens (older than TOKEN_LIFETIME) are automatically cleared.
- *
- * Uses `execFileSync` (not `execSync`) to avoid shell injection risks.
  */
 
-import { execFileSync } from "node:child_process";
 import type { TeamsToken } from "./types.js";
+import { createCredentialStore } from "./credential-store.js";
 
-const KEYCHAIN_SERVICE = "teams-api";
 const TOKEN_LIFETIME = 23 * 60 * 60 * 1_000; // 23 hours (tokens last ~24h, 1h safety margin)
 
 interface StoredToken {
@@ -21,6 +19,8 @@ interface StoredToken {
   substrateToken?: string;
   acquiredAt: number;
 }
+
+const store = createCredentialStore();
 
 export function saveToken(email: string, token: TeamsToken): void {
   const storedToken: StoredToken = {
@@ -32,27 +32,12 @@ export function saveToken(email: string, token: TeamsToken): void {
   };
   const encoded = Buffer.from(JSON.stringify(storedToken)).toString("base64");
 
-  execFileSync("security", [
-    "add-generic-password",
-    "-a",
-    email,
-    "-s",
-    KEYCHAIN_SERVICE,
-    "-w",
-    encoded,
-    "-U",
-  ]);
+  store.save(email, encoded);
 }
 
 export function loadToken(email: string): TeamsToken | null {
-  let encoded: string;
-  try {
-    encoded = execFileSync(
-      "security",
-      ["find-generic-password", "-a", email, "-s", KEYCHAIN_SERVICE, "-w"],
-      { encoding: "utf-8" },
-    ).trim();
-  } catch {
+  const encoded = store.load(email);
+  if (!encoded) {
     return null;
   }
 
@@ -80,15 +65,5 @@ export function loadToken(email: string): TeamsToken | null {
 }
 
 export function clearToken(email: string): void {
-  try {
-    execFileSync("security", [
-      "delete-generic-password",
-      "-a",
-      email,
-      "-s",
-      KEYCHAIN_SERVICE,
-    ]);
-  } catch {
-    // Token may not exist in keychain, that's fine
-  }
+  store.clear(email);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,16 @@ export interface InteractiveLoginOptions {
   verbose?: boolean;
 }
 
+/** Options for smart login (zero-config default path). */
+export interface SmartLoginOptions {
+  /** Corporate email (optional — skips auto-login if not provided). */
+  email?: string;
+  /** Explicit API region override. Omit to auto-detect when possible. */
+  region?: string;
+  /** Emit progress messages to console (default: false). */
+  verbose?: boolean;
+}
+
 /** Options for manual token capture from a running Chrome debug session. */
 export interface ManualTokenOptions {
   /** Chrome DevTools Protocol debug port (default: 9222). */

--- a/tests/unit/browser-runtime.test.ts
+++ b/tests/unit/browser-runtime.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for browser runtime helpers (src/browser-runtime.ts).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Browser } from "playwright";
+import {
+  getInteractiveBrowserChannels,
+  isMissingPlaywrightBrowserError,
+  launchInteractiveBrowser,
+} from "../../src/browser-runtime.js";
+
+function createBrowserStub(): Browser {
+  return {} as Browser;
+}
+
+describe("getInteractiveBrowserChannels", () => {
+  it("should prefer Edge then Chrome on Windows", () => {
+    expect(getInteractiveBrowserChannels("win32")).toEqual([
+      "msedge",
+      "chrome",
+    ]);
+  });
+
+  it("should prefer Chrome on macOS", () => {
+    expect(getInteractiveBrowserChannels("darwin")).toEqual(["chrome"]);
+  });
+
+  it("should prefer Chrome then Edge on Linux", () => {
+    expect(getInteractiveBrowserChannels("linux")).toEqual([
+      "chrome",
+      "msedge",
+    ]);
+  });
+});
+
+describe("isMissingPlaywrightBrowserError", () => {
+  it("should detect a missing bundled-browser executable", () => {
+    expect(
+      isMissingPlaywrightBrowserError(
+        new Error("Executable doesn't exist at C:\\Users\\me\\browser.exe"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should ignore unrelated launch errors", () => {
+    expect(isMissingPlaywrightBrowserError(new Error("Launch crashed"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("launchInteractiveBrowser", () => {
+  it("should use the first available installed browser channel", async () => {
+    const browser = createBrowserStub();
+    const chromium = {
+      launch: vi.fn().mockResolvedValue(browser),
+    };
+
+    const result = await launchInteractiveBrowser(chromium, vi.fn(), {
+      platform: "win32",
+      installBundledChromium: vi.fn(),
+    });
+
+    expect(result).toBe(browser);
+    expect(chromium.launch).toHaveBeenCalledTimes(1);
+    expect(chromium.launch).toHaveBeenCalledWith({
+      headless: false,
+      channel: "msedge",
+    });
+  });
+
+  it("should fall back to the next installed browser channel", async () => {
+    const browser = createBrowserStub();
+    const chromium = {
+      launch: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Edge not installed"))
+        .mockResolvedValueOnce(browser),
+    };
+
+    const result = await launchInteractiveBrowser(chromium, vi.fn(), {
+      platform: "win32",
+      installBundledChromium: vi.fn(),
+    });
+
+    expect(result).toBe(browser);
+    expect(chromium.launch).toHaveBeenNthCalledWith(1, {
+      headless: false,
+      channel: "msedge",
+    });
+    expect(chromium.launch).toHaveBeenNthCalledWith(2, {
+      headless: false,
+      channel: "chrome",
+    });
+  });
+
+  it("should fall back to bundled Chromium when installed channels fail", async () => {
+    const browser = createBrowserStub();
+    const chromium = {
+      launch: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Edge not installed"))
+        .mockRejectedValueOnce(new Error("Chrome not installed"))
+        .mockResolvedValueOnce(browser),
+    };
+
+    const result = await launchInteractiveBrowser(chromium, vi.fn(), {
+      platform: "win32",
+      installBundledChromium: vi.fn(),
+    });
+
+    expect(result).toBe(browser);
+    expect(chromium.launch).toHaveBeenNthCalledWith(3, {
+      headless: false,
+    });
+  });
+
+  it("should install bundled Chromium and retry when it is missing", async () => {
+    const browser = createBrowserStub();
+    const installBundledChromium = vi.fn();
+    const chromium = {
+      launch: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Edge not installed"))
+        .mockRejectedValueOnce(new Error("Chrome not installed"))
+        .mockRejectedValueOnce(
+          new Error("Executable doesn't exist at C:\\Users\\me\\browser.exe"),
+        )
+        .mockResolvedValueOnce(browser),
+    };
+
+    const result = await launchInteractiveBrowser(chromium, vi.fn(), {
+      platform: "win32",
+      installBundledChromium,
+    });
+
+    expect(result).toBe(browser);
+    expect(installBundledChromium).toHaveBeenCalledTimes(1);
+    expect(chromium.launch).toHaveBeenNthCalledWith(4, {
+      headless: false,
+    });
+  });
+
+  it("should rethrow non-installable bundled Chromium launch errors", async () => {
+    const chromium = {
+      launch: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Chrome not installed"))
+        .mockRejectedValueOnce(new Error("Edge not installed"))
+        .mockRejectedValueOnce(new Error("Browser sandbox failure")),
+    };
+
+    await expect(
+      launchInteractiveBrowser(chromium, vi.fn(), {
+        platform: "linux",
+        installBundledChromium: vi.fn(),
+      }),
+    ).rejects.toThrow("Browser sandbox failure");
+  });
+});

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the credential store factory (src/credential-store.ts).
+ *
+ * Tests the factory function and verifies platform selection logic.
+ * Individual store implementations are tested via the token-store tests
+ * and integration tests on each platform.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We need to re-import after changing platform, so we use dynamic imports
+describe("createCredentialStore", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    vi.restoreAllMocks();
+  });
+
+  it("should return a KeychainStore on macOS", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    // Re-import to pick up the new platform value
+    const { createCredentialStore } =
+      await import("../../src/credential-store.js");
+    const store = createCredentialStore();
+
+    expect(store).toBeDefined();
+    expect(store.save).toBeTypeOf("function");
+    expect(store.load).toBeTypeOf("function");
+    expect(store.clear).toBeTypeOf("function");
+  });
+
+  it("should return a WinCredStore on Windows", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    const { createCredentialStore } =
+      await import("../../src/credential-store.js");
+    const store = createCredentialStore();
+
+    expect(store).toBeDefined();
+    expect(store.save).toBeTypeOf("function");
+    expect(store.load).toBeTypeOf("function");
+    expect(store.clear).toBeTypeOf("function");
+  });
+
+  it("should return a LinuxStore on Linux", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    const { createCredentialStore } =
+      await import("../../src/credential-store.js");
+    const store = createCredentialStore();
+
+    expect(store).toBeDefined();
+    expect(store.save).toBeTypeOf("function");
+    expect(store.load).toBeTypeOf("function");
+    expect(store.clear).toBeTypeOf("function");
+  });
+});

--- a/tests/unit/platform.test.ts
+++ b/tests/unit/platform.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the platform detection module (src/platform.ts).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+describe("detectPlatform", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("should return 'macos' on darwin", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { detectPlatform } = await import("../../src/platform.js");
+    expect(detectPlatform()).toBe("macos");
+  });
+
+  it("should return 'windows' on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const { detectPlatform } = await import("../../src/platform.js");
+    expect(detectPlatform()).toBe("windows");
+  });
+
+  it("should return 'linux' on linux", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { detectPlatform } = await import("../../src/platform.js");
+    expect(detectPlatform()).toBe("linux");
+  });
+
+  it("should return 'linux' on freebsd", async () => {
+    Object.defineProperty(process, "platform", { value: "freebsd" });
+    const { detectPlatform } = await import("../../src/platform.js");
+    expect(detectPlatform()).toBe("linux");
+  });
+});
+
+describe("canAttemptAutoLogin", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    vi.restoreAllMocks();
+  });
+
+  it("should return false on Windows", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const { canAttemptAutoLogin } = await import("../../src/platform.js");
+    expect(canAttemptAutoLogin()).toBe(false);
+  });
+
+  it("should return false on Linux", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { canAttemptAutoLogin } = await import("../../src/platform.js");
+    expect(canAttemptAutoLogin()).toBe(false);
+  });
+
+  it("should return false on macOS when Chrome is not found", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { canAttemptAutoLogin } = await import("../../src/platform.js");
+    // Pass a path that definitely doesn't exist
+    expect(canAttemptAutoLogin("/nonexistent/chrome")).toBe(false);
+  });
+});

--- a/tests/unit/smart-login.test.ts
+++ b/tests/unit/smart-login.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the smart login flow (src/smart-login.ts).
+ *
+ * Tests the decision logic: when to try auto-login vs interactive,
+ * and the fallback behavior when auto-login fails.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TeamsToken } from "../../src/types.js";
+
+vi.mock("../../src/platform.js");
+vi.mock("../../src/auth.js");
+
+import { acquireTokenViaSmartLogin } from "../../src/smart-login.js";
+import * as auth from "../../src/auth.js";
+import * as platform from "../../src/platform.js";
+
+const mockedAuth = vi.mocked(auth);
+const mockedPlatform = vi.mocked(platform);
+
+const testToken: TeamsToken = {
+  skypeToken: "test-token",
+  region: "apac",
+  bearerToken: "bearer",
+  substrateToken: "substrate",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("acquireTokenViaSmartLogin", () => {
+  it("should try auto-login when email provided and prerequisites met", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(true);
+    mockedAuth.acquireTokenViaAutoLogin.mockResolvedValue(testToken);
+
+    const result = await acquireTokenViaSmartLogin({
+      email: "user@company.com",
+    });
+
+    expect(result).toEqual(testToken);
+    expect(mockedAuth.acquireTokenViaAutoLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "user@company.com",
+        headless: true,
+      }),
+    );
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to interactive when auto-login fails", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(true);
+    mockedAuth.acquireTokenViaAutoLogin.mockRejectedValue(
+      new Error("FIDO2 not enrolled"),
+    );
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(testToken);
+
+    const result = await acquireTokenViaSmartLogin({
+      email: "user@company.com",
+    });
+
+    expect(result).toEqual(testToken);
+    expect(mockedAuth.acquireTokenViaAutoLogin).toHaveBeenCalled();
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "user@company.com" }),
+    );
+  });
+
+  it("should go straight to interactive when no email provided", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(true);
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(testToken);
+
+    const result = await acquireTokenViaSmartLogin({});
+
+    expect(result).toEqual(testToken);
+    expect(mockedAuth.acquireTokenViaAutoLogin).not.toHaveBeenCalled();
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).toHaveBeenCalled();
+  });
+
+  it("should go straight to interactive when auto-login prerequisites not met", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(false);
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(testToken);
+
+    const result = await acquireTokenViaSmartLogin({
+      email: "user@company.com",
+    });
+
+    expect(result).toEqual(testToken);
+    expect(mockedAuth.acquireTokenViaAutoLogin).not.toHaveBeenCalled();
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).toHaveBeenCalled();
+  });
+
+  it("should pass region to both auto and interactive login", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(true);
+    mockedAuth.acquireTokenViaAutoLogin.mockRejectedValue(new Error("fail"));
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(testToken);
+
+    await acquireTokenViaSmartLogin({
+      email: "user@company.com",
+      region: "emea",
+    });
+
+    expect(mockedAuth.acquireTokenViaAutoLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "emea" }),
+    );
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "emea" }),
+    );
+  });
+
+  it("should work with no options at all", async () => {
+    mockedPlatform.canAttemptAutoLogin.mockReturnValue(false);
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(testToken);
+
+    const result = await acquireTokenViaSmartLogin();
+
+    expect(result).toEqual(testToken);
+    expect(mockedAuth.acquireTokenViaInteractiveLogin).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -12,6 +12,7 @@ import * as api from "../../src/api.js";
 import { ApiAuthError } from "../../src/api.js";
 import * as tokenStore from "../../src/token-store.js";
 import * as auth from "../../src/auth.js";
+import * as smartLogin from "../../src/smart-login.js";
 import type {
   Conversation,
   Message,
@@ -36,8 +37,11 @@ vi.mock("../../src/api.js", async (importOriginal) => {
 });
 vi.mock("../../src/token-store.js");
 vi.mock("../../src/auth.js");
+vi.mock("../../src/smart-login.js");
+vi.mock("../../src/platform.js");
 
 const mockedApi = vi.mocked(api);
+const mockedSmartLogin = vi.mocked(smartLogin);
 const mockedTokenStore = vi.mocked(tokenStore);
 const mockedAuth = vi.mocked(auth);
 
@@ -1206,6 +1210,108 @@ describe("withTokenRefresh (automatic 401 retry)", () => {
 
     await expect(client.listConversations()).rejects.toThrow(
       "Authentication failed: 401",
+    );
+  });
+});
+
+describe("TeamsClient.connect", () => {
+  it("should use cached token when email is provided and cache exists", async () => {
+    const cachedToken = { skypeToken: "cached-token", region: "apac" };
+    mockedTokenStore.loadToken.mockReturnValue(cachedToken);
+
+    const client = await TeamsClient.connect({
+      email: "user@company.com",
+    });
+
+    expect(mockedTokenStore.loadToken).toHaveBeenCalledWith("user@company.com");
+    expect(mockedSmartLogin.acquireTokenViaSmartLogin).not.toHaveBeenCalled();
+    expect(client.getToken()).toEqual(cachedToken);
+  });
+
+  it("should call smart login when no cached token exists", async () => {
+    const freshToken = { skypeToken: "fresh-token", region: "apac" };
+    mockedTokenStore.loadToken.mockReturnValue(null);
+    mockedSmartLogin.acquireTokenViaSmartLogin.mockResolvedValue(freshToken);
+
+    const client = await TeamsClient.connect({
+      email: "user@company.com",
+    });
+
+    expect(mockedSmartLogin.acquireTokenViaSmartLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "user@company.com" }),
+    );
+    expect(mockedTokenStore.saveToken).toHaveBeenCalledWith(
+      "user@company.com",
+      freshToken,
+    );
+    expect(client.getToken()).toEqual(freshToken);
+  });
+
+  it("should call smart login without caching when no email provided", async () => {
+    const freshToken = { skypeToken: "fresh-token", region: "apac" };
+    mockedSmartLogin.acquireTokenViaSmartLogin.mockResolvedValue(freshToken);
+
+    const client = await TeamsClient.connect();
+
+    expect(mockedTokenStore.loadToken).not.toHaveBeenCalled();
+    expect(mockedSmartLogin.acquireTokenViaSmartLogin).toHaveBeenCalledWith(
+      undefined,
+    );
+    expect(mockedTokenStore.saveToken).not.toHaveBeenCalled();
+    expect(client.getToken()).toEqual(freshToken);
+  });
+
+  it("should apply an explicit region override to a cached token", async () => {
+    const cachedToken = { skypeToken: "cached-token", region: "apac" };
+    mockedTokenStore.loadToken.mockReturnValue(cachedToken);
+
+    const client = await TeamsClient.connect({
+      email: "user@company.com",
+      region: "emea",
+    });
+
+    expect(mockedSmartLogin.acquireTokenViaSmartLogin).not.toHaveBeenCalled();
+    expect(mockedTokenStore.saveToken).toHaveBeenCalledWith(
+      "user@company.com",
+      { ...cachedToken, region: "emea" },
+    );
+    expect(client.getToken()).toEqual({
+      ...cachedToken,
+      region: "emea",
+    });
+  });
+
+  it("should refresh token via smart login on 401", async () => {
+    const initialToken = { skypeToken: "old-token", region: "apac" };
+    const refreshedToken = { skypeToken: "new-token", region: "apac" };
+    mockedTokenStore.loadToken.mockReturnValue(initialToken);
+
+    const client = await TeamsClient.connect({
+      email: "user@company.com",
+    });
+
+    // First call fails with 401
+    mockedApi.fetchConversations
+      .mockRejectedValueOnce(new ApiAuthError("Authentication failed: 401"))
+      .mockResolvedValueOnce([makeConversation({ topic: "After Refresh" })]);
+
+    mockedSmartLogin.acquireTokenViaSmartLogin.mockResolvedValue(
+      refreshedToken,
+    );
+
+    const conversations = await client.listConversations();
+
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0].topic).toBe("After Refresh");
+
+    // Verify smart login refresh happened
+    expect(mockedTokenStore.clearToken).toHaveBeenCalledWith(
+      "user@company.com",
+    );
+    expect(mockedSmartLogin.acquireTokenViaSmartLogin).toHaveBeenCalled();
+    expect(mockedTokenStore.saveToken).toHaveBeenCalledWith(
+      "user@company.com",
+      refreshedToken,
     );
   });
 });

--- a/tests/unit/token-store.test.ts
+++ b/tests/unit/token-store.test.ts
@@ -1,19 +1,33 @@
 /**
  * Unit tests for the token store (src/token-store.ts).
  *
- * These tests mock `execFileSync` from `node:child_process` to verify
- * that the token store correctly interacts with the macOS Keychain.
+ * These tests mock the credential store to verify that the token store
+ * correctly handles token serialization, expiry, and lifecycle.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { TeamsToken } from "../../src/types.js";
 
-vi.mock("node:child_process");
+vi.mock("../../src/credential-store.js", () => {
+  const store = {
+    save: vi.fn(),
+    load: vi.fn(),
+    clear: vi.fn(),
+  };
+  return {
+    createCredentialStore: () => store,
+    _mockStore: store,
+  };
+});
 
-import { execFileSync } from "node:child_process";
 import { saveToken, loadToken, clearToken } from "../../src/token-store.js";
+import { createCredentialStore } from "../../src/credential-store.js";
 
-const mockedExecFileSync = vi.mocked(execFileSync);
+const mockStore = createCredentialStore() as {
+  save: ReturnType<typeof vi.fn>;
+  load: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+};
 
 const testEmail = "user@company.com";
 const testToken: TeamsToken = {
@@ -51,27 +65,17 @@ function makeStoredTokenBase64(
 }
 
 describe("saveToken", () => {
-  it("should call security CLI with correct arguments", () => {
+  it("should call credential store with correct account", () => {
     saveToken(testEmail, testToken);
 
-    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecFileSync).toHaveBeenCalledWith("security", [
-      "add-generic-password",
-      "-a",
-      testEmail,
-      "-s",
-      "teams-api",
-      "-w",
-      expect.any(String),
-      "-U",
-    ]);
+    expect(mockStore.save).toHaveBeenCalledTimes(1);
+    expect(mockStore.save).toHaveBeenCalledWith(testEmail, expect.any(String));
   });
 
   it("should store base64-encoded JSON with acquiredAt timestamp", () => {
     saveToken(testEmail, testToken);
 
-    const encodedValue = (mockedExecFileSync as ReturnType<typeof vi.fn>).mock
-      .calls[0][1][6] as string;
+    const encodedValue = mockStore.save.mock.calls[0][1] as string;
     const decoded = JSON.parse(
       Buffer.from(encodedValue, "base64").toString("utf-8"),
     ) as {
@@ -90,8 +94,7 @@ describe("saveToken", () => {
   it("should persist optional bearer and substrate tokens", () => {
     saveToken(testEmail, testTokenWithAuxiliaryTokens);
 
-    const encodedValue = (mockedExecFileSync as ReturnType<typeof vi.fn>).mock
-      .calls[0][1][6] as string;
+    const encodedValue = mockStore.save.mock.calls[0][1] as string;
     const decoded = JSON.parse(
       Buffer.from(encodedValue, "base64").toString("utf-8"),
     ) as {
@@ -110,16 +113,12 @@ describe("saveToken", () => {
 describe("loadToken", () => {
   it("should return token when cached and not expired", () => {
     const encoded = makeStoredTokenBase64();
-    mockedExecFileSync.mockReturnValueOnce(encoded as never);
+    mockStore.load.mockReturnValueOnce(encoded);
 
     const result = loadToken(testEmail);
 
     expect(result).toEqual(testToken);
-    expect(mockedExecFileSync).toHaveBeenCalledWith(
-      "security",
-      ["find-generic-password", "-a", testEmail, "-s", "teams-api", "-w"],
-      { encoding: "utf-8" },
-    );
+    expect(mockStore.load).toHaveBeenCalledWith(testEmail);
   });
 
   it("should restore optional bearer and substrate tokens", () => {
@@ -132,19 +131,15 @@ describe("loadToken", () => {
         acquiredAt: new Date("2026-03-17T12:00:00.000Z").getTime(),
       }),
     ).toString("base64");
-    mockedExecFileSync.mockReturnValueOnce(encoded as never);
+    mockStore.load.mockReturnValueOnce(encoded);
 
     const result = loadToken(testEmail);
 
     expect(result).toEqual(testTokenWithAuxiliaryTokens);
   });
 
-  it("should return null when no token exists in keychain", () => {
-    mockedExecFileSync.mockImplementation(() => {
-      throw new Error(
-        "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.",
-      );
-    });
+  it("should return null when no token exists", () => {
+    mockStore.load.mockReturnValueOnce(null);
 
     const result = loadToken(testEmail);
 
@@ -155,19 +150,12 @@ describe("loadToken", () => {
     const twentyFourHoursAgo =
       new Date("2026-03-17T12:00:00.000Z").getTime() - 24 * 60 * 60 * 1_000;
     const encoded = makeStoredTokenBase64({ acquiredAt: twentyFourHoursAgo });
-    mockedExecFileSync.mockReturnValueOnce(encoded as never);
+    mockStore.load.mockReturnValueOnce(encoded);
 
     const result = loadToken(testEmail);
 
     expect(result).toBeNull();
-    // Should have called delete-generic-password to clear expired token
-    expect(mockedExecFileSync).toHaveBeenCalledWith("security", [
-      "delete-generic-password",
-      "-a",
-      testEmail,
-      "-s",
-      "teams-api",
-    ]);
+    expect(mockStore.clear).toHaveBeenCalledWith(testEmail);
   });
 
   it("should return token when acquired exactly 22 hours ago", () => {
@@ -176,7 +164,7 @@ describe("loadToken", () => {
     const encoded = makeStoredTokenBase64({
       acquiredAt: twentyTwoHoursAgo,
     });
-    mockedExecFileSync.mockReturnValueOnce(encoded as never);
+    mockStore.load.mockReturnValueOnce(encoded);
 
     const result = loadToken(testEmail);
 
@@ -184,42 +172,19 @@ describe("loadToken", () => {
   });
 
   it("should return null and clear token when data is corrupted", () => {
-    mockedExecFileSync.mockReturnValueOnce("not-valid-base64!!!" as never);
+    mockStore.load.mockReturnValueOnce("not-valid-base64!!!");
 
     const result = loadToken(testEmail);
 
     expect(result).toBeNull();
-    // Should have tried to clear the corrupted entry
-    expect(mockedExecFileSync).toHaveBeenCalledWith("security", [
-      "delete-generic-password",
-      "-a",
-      testEmail,
-      "-s",
-      "teams-api",
-    ]);
+    expect(mockStore.clear).toHaveBeenCalledWith(testEmail);
   });
 });
 
 describe("clearToken", () => {
-  it("should call security CLI to delete the keychain entry", () => {
+  it("should call credential store clear", () => {
     clearToken(testEmail);
 
-    expect(mockedExecFileSync).toHaveBeenCalledWith("security", [
-      "delete-generic-password",
-      "-a",
-      testEmail,
-      "-s",
-      "teams-api",
-    ]);
-  });
-
-  it("should not throw when token does not exist in keychain", () => {
-    mockedExecFileSync.mockImplementation(() => {
-      throw new Error(
-        "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.",
-      );
-    });
-
-    expect(() => clearToken(testEmail)).not.toThrow();
+    expect(mockStore.clear).toHaveBeenCalledWith(testEmail);
   });
 });


### PR DESCRIPTION
## Summary

Implements #2 — smart cross-platform login and zero-config onboarding.

- **New default auth**: Smart login (`TeamsClient.connect()`) replaces the debug session as the default. It auto-detects the best auth strategy for the platform — auto-login on macOS if Chrome + email are available, interactive browser login otherwise. No env vars needed.
- **Cross-platform credential store**: Token caching now works on all platforms — macOS Keychain, Windows DPAPI-encrypted files, Linux `secret-tool` (libsecret) with plain-file fallback.
- **Debug session moved to explicit opt-in**: `TEAMS_DEBUG=true` env var for MCP, `--debug` flag for CLI.

### New files

| File | Purpose |
|------|---------|
| `src/credential-store.ts` | `CredentialStore` interface + 3 platform implementations (KeychainStore, WinCredStore, LinuxStore) |
| `src/platform.ts` | `detectPlatform()` and `canAttemptAutoLogin()` |
| `src/smart-login.ts` | `acquireTokenViaSmartLogin()` — strategy selection with auto-login → interactive fallback |

### Modified files

| File | Changes |
|------|---------|
| `src/token-store.ts` | Refactored to delegate raw storage to `createCredentialStore()` |
| `src/types.ts` | Added `SmartLoginOptions` interface |
| `src/teams-client.ts` | Added `TeamsClient.connect()`, updated `refreshToken` to support smart login path |
| `src/mcp-server.ts` | Default path uses `connect()`, debug session behind `TEAMS_DEBUG` |
| `src/cli.ts` | Default path uses `connect()`, debug session behind `--debug` flag |
| `README.md` | Updated platform support table, auth docs, env vars, programmatic API examples |
| `server.json` | Added `TEAMS_DEBUG` env var to MCP registry metadata |

### Auth flow comparison

**Before:**
```
TEAMS_TOKEN  → fromToken
TEAMS_AUTO   → create() (macOS)
TEAMS_LOGIN  → fromInteractiveLogin
(default)    → debug session on port 9222 (broken for new users)
```

**After:**
```
TEAMS_TOKEN  → fromToken (unchanged)
TEAMS_AUTO   → create() (unchanged)
TEAMS_LOGIN  → fromInteractiveLogin (unchanged)
TEAMS_DEBUG  → debug session (moved from default to explicit)
(default)    → TeamsClient.connect() — smart login
```

## Test plan

- [x] All 266 unit tests pass (`npm run test:unit`)
- [x] TypeScript type check passes (`npm run type-check`)
- [x] Prettier lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] **macOS with FIDO2**: `npx teams-api-mcp` with `TEAMS_EMAIL` set → should auto-login silently
- [ ] **macOS without FIDO2**: Same → should fall back to interactive browser login
- [ ] **macOS no env vars**: `npx teams-api-mcp` → interactive login opens
- [ ] **Windows no env vars**: Same → interactive login opens
- [ ] **Existing env vars**: `TEAMS_AUTO=true`, `TEAMS_LOGIN=true`, `TEAMS_TOKEN` → all work as before
- [ ] **Token caching**: Second run reuses cached token on all platforms
- [ ] **Token refresh**: 401 triggers smart re-login

## How to verify on Windows

### Prerequisites

1. Install [Node.js 22+](https://nodejs.org/) (LTS recommended)
2. Clone this repo and checkout the `feat/smart-login` branch:
   ```powershell
   git clone https://github.com/Maxim-Mazurok/teams-api.git
   cd teams-api
   git checkout feat/smart-login
   npm install
   ```
3. Install Playwright browsers (needed for interactive login):
   ```powershell
   npx playwright install chromium
   ```

### Test 1: Smart login (zero-config)

No env vars needed — should open a browser window for interactive login:

```powershell
# From source
npx tsx src/cli.ts auth
# The token JSON should be printed after login

# Or via MCP server (stdio, use Ctrl+C to stop)
npx tsx src/mcp-server.ts
```

### Test 2: Token caching on Windows

```powershell
# First run — should open browser for login
$env:TEAMS_EMAIL = "you@company.com"
npx tsx src/cli.ts auth

# Second run — should use cached token (no browser opens)
npx tsx src/cli.ts list-conversations
```

Verify the DPAPI-encrypted credential file exists:
```powershell
dir "$env:APPDATA\teams-api\"
# Should contain a .dat file (SHA-256 hash of email)
```

### Test 3: Logout (clear cached token)

```powershell
npx tsx src/cli.ts logout --email you@company.com
# Should print "Cached token for you@company.com cleared."

# Verify file is gone
dir "$env:APPDATA\teams-api\"
```

### Test 4: Explicit auth strategies still work

```powershell
# Interactive login (explicit)
npx tsx src/cli.ts auth --login

# Debug session (explicit)
# First start Chrome: chrome.exe --remote-debugging-port=9222
# Then navigate to teams.cloud.microsoft.com and log in
npx tsx src/cli.ts auth --debug --debug-port 9222

# Direct token
npx tsx src/cli.ts list-conversations --token "paste-token-here" --region emea
```

### Test 5: Unit tests

```powershell
npm run test:unit
# All tests should pass
```

### Test 6: MCP server in VS Code

Add to `.vscode/mcp.json` (no env vars needed for zero-config):
```json
{
  "mcpServers": {
    "teams": {
      "command": "npx",
      "args": ["tsx", "src/mcp-server.ts"]
    }
  }
}
```

Start the MCP server from VS Code. On first tool call, a browser should open for login. Subsequent calls should use the cached token.


🤖 Generated with [Claude Code](https://claude.com/claude-code)