### PR TITLE
fix: clear substrate token polling interval on timeout

### DIFF
--- a/src/auth/token-capture.ts
+++ b/src/auth/token-capture.ts
@@ -130,15 +130,18 @@ export async function captureTokensFromPage(
   if (skypeToken && !substrateToken) {
     log("Waiting for substrate token...");
     await new Promise<void>((resolve) => {
-      const extraTimeout = setTimeout(resolve, 5_000);
       const checkInterval = setInterval(() => {
         if (substrateToken) {
-          clearTimeout(extraTimeout);
           clearInterval(checkInterval);
           resolve();
         }
       }, 200);
+      const extraTimeout = setTimeout(() => {
+        clearInterval(checkInterval);
+        resolve();
+      }, 5_000);
       extraTimeout.unref?.();
+      checkInterval.unref?.();
     });
   }
 


### PR DESCRIPTION
The substrate token polling `setInterval` (200ms) was never cleared when the 5-second timeout fired. This kept the Node.js event loop alive indefinitely after `browser.close()`.

Fix: clear the interval in the timeout callback, and `unref()` both timers as a safety net.

Verified with a minimal repro script — process now exits cleanly after auth.