### PR TITLE
feat: resolve emoji catalog version dynamically from Teams ECS config

### DIFF
--- a/src/emoji-map.ts
+++ b/src/emoji-map.ts
@@ -103,7 +103,15 @@ async function fetchCurrentVersion(): Promise<string | null> {
       );
       return null;
     }
-    return match[1];
+    const version = match[1];
+    // Validate: must be a 32-char lowercase hex hash to avoid malformed URLs
+    if (!/^[0-9a-f]{32}$/.test(version)) {
+      console.warn(
+        `[emoji-map] Unexpected emoticonAssetVersion format "${version}", will use fallback versions`,
+      );
+      return null;
+    }
+    return version;
   } catch (error) {
     console.warn(
       "[emoji-map] Failed to fetch ECS config:",

--- a/tests/unit/emoji-map.test.ts
+++ b/tests/unit/emoji-map.test.ts
@@ -111,6 +111,46 @@ describe("initializeEmojiMap", () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
+  it("falls back to hardcoded versions when ECS returns a version not on the CDN", async () => {
+    // ECS gives a version hash, but CDN 404s for it; hardcoded fallback succeeds
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes("config.teams.microsoft.com")) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(TEST_ECS_RESPONSE) });
+        }
+        if (url.includes(TEST_ECS_VERSION)) {
+          return Promise.resolve({ ok: false, status: 404 });
+        }
+        // Fallback CDN versions succeed
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+      }),
+    );
+    await initializeEmojiMap();
+    expect(resolveReactionKey("horse")).toBe("1f40e_horse");
+    const calls = vi.mocked(fetch).mock.calls.map((c) => c[0] as string);
+    // ECS call, ECS-version CDN call (404), then a fallback version CDN call
+    expect(calls.filter((u) => u.includes("statics.teams.cdn.office.net")).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("validates the ECS version format and falls back on malformed values", async () => {
+    const malformedEcsResponse = '{"emoticonAssetVersion":"not-a-valid-hash"}';
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes("config.teams.microsoft.com")) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(malformedEcsResponse) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+      }),
+    );
+    await initializeEmojiMap();
+    // Should still succeed via fallback versions
+    expect(resolveReactionKey("horse")).toBe("1f40e_horse");
+    const warnings = vi.mocked(console.warn).mock.calls.map((c) => c[0] as string);
+    expect(warnings.some((w) => w.includes("Unexpected emoticonAssetVersion format"))).toBe(true);
+  });
+
   it("falls back to hardcoded versions when ECS is unreachable", async () => {
     mockFetchEcsFailCdnSuccess();
     await initializeEmojiMap();


### PR DESCRIPTION
Closes #9

## What changed

`src/emoji-map.ts` now resolves the current emoji catalog version dynamically from the Teams ECS (Experimentation and Configuration Service) config endpoint before falling back to hardcoded version hashes.

### Fetch sequence

1. **ECS config** (`config.teams.microsoft.com/config/v1/MicrosoftTeams/1415_1.0.0.0?...`) — publicly accessible, no auth. Extracts `emoticonAssetVersion` via regex.
2. **CDN with ECS version** — `statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v1/metadata/{version}/en-gb.json`
3. **Fallback: hardcoded versions** — tried if ECS is unreachable or the resolved version isn't on the CDN.
4. **Fallback: lowercased input** — standard reactions (`like`, `heart`, etc.) still work without any map since their ID equals their shortcut.

The hardcoded versions are now labelled `FALLBACK_VERSIONS` to clarify their role.

## Tests

Updated `tests/unit/emoji-map.test.ts` to mock both the ECS and CDN fetch calls, covering:
- Happy path: ECS resolves version → CDN returns catalog
- ECS failure → falls back to hardcoded versions → catalog loads
- All fetches fail → no throw, warnings logged
- Idempotency