### PR TITLE
fix: resolve display names for untitled group chats

### DIFF
--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -514,19 +514,30 @@ export class TeamsClient {
           )
         : conversations;
 
-      // Resolve display names for untitled 1:1 chats.
-      await this.resolveOneOnOneDisplayNames(filtered);
+      // Resolve display names for untitled chats (1:1 and group).
+      await this.resolveUntitledDisplayNames(filtered);
 
       return filtered;
     });
   }
 
   /**
-   * Enrich untitled 1:1 conversations with the other member's display name.
+   * Enrich untitled conversations with display names derived from members.
+   *
+   * - 1:1 chats → other member's display name (e.g. "Alice Smith")
+   * - Group chats → comma-separated member names excluding the current user
+   *   (e.g. "Alice, Bob"), matching the Teams UI behavior
    */
-  private async resolveOneOnOneDisplayNames(
+  private async resolveUntitledDisplayNames(
     conversations: Conversation[],
   ): Promise<void> {
+    const untitledGroupChats = conversations.filter(
+      (conversation) =>
+        !conversation.topic &&
+        conversation.id.includes("@thread.v2") &&
+        !conversation.id.startsWith("48:"),
+    );
+
     const untitledOneOnOnes = conversations.filter(
       (conversation) =>
         !conversation.topic &&
@@ -534,11 +545,36 @@ export class TeamsClient {
         !conversation.id.startsWith("48:"),
     );
 
-    if (untitledOneOnOnes.length === 0) return;
+    if (untitledOneOnOnes.length === 0 && untitledGroupChats.length === 0) {
+      return;
+    }
+
     const currentUserIdentity = await this.resolveCurrentUserIdentity({
       allowSelfChatFallback: false,
     });
-    const currentUserDisplayName = currentUserIdentity.displayName.toLowerCase();
+    const currentUserDisplayName =
+      currentUserIdentity.displayName.toLowerCase();
+
+    // Resolve untitled group chats by fetching members and joining names.
+    for (const chat of untitledGroupChats) {
+      try {
+        const members = await this.getMembers(chat.id);
+        const otherMemberNames = members
+          .filter(
+            (member) =>
+              member.displayName &&
+              member.displayName.toLowerCase() !== currentUserDisplayName,
+          )
+          .map((member) => member.displayName);
+        if (otherMemberNames.length > 0) {
+          chat.topic = otherMemberNames.join(", ");
+        }
+      } catch {
+        // Member fetch failed — leave topic empty.
+      }
+    }
+
+    if (untitledOneOnOnes.length === 0) return;
 
     for (const chat of untitledOneOnOnes) {
       try {

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -245,6 +245,63 @@ describe("listConversations", () => {
     expect(conversations[0].topic).toBe("Bob Jones");
   });
 
+  it("should resolve untitled group chats using member names", async () => {
+    mockedApi.fetchConversations.mockResolvedValueOnce([
+      makeConversation({
+        id: "19:abc123def456@thread.v2",
+        topic: "",
+        threadType: "chat",
+      }),
+    ]);
+    mockedApi.fetchUserProperties.mockResolvedValueOnce({
+      userDetails: JSON.stringify({ name: "Alice Smith" }),
+    });
+    mockedApi.fetchMembers.mockResolvedValueOnce([
+      {
+        id: "8:orgid:self",
+        displayName: "Alice Smith",
+        role: "Admin",
+        memberType: "person",
+      },
+      {
+        id: "8:orgid:other1",
+        displayName: "Bob Jones",
+        role: "Admin",
+        memberType: "person",
+      },
+      {
+        id: "8:orgid:other2",
+        displayName: "Charlie Brown",
+        role: "Admin",
+        memberType: "person",
+      },
+    ]);
+
+    const client = TeamsClient.fromToken("token");
+    const conversations = await client.listConversations();
+
+    expect(conversations[0].topic).toBe("Bob Jones, Charlie Brown");
+  });
+
+  it("should leave untitled group chat topic empty when member fetch fails", async () => {
+    mockedApi.fetchConversations.mockResolvedValueOnce([
+      makeConversation({
+        id: "19:abc123def456@thread.v2",
+        topic: "",
+        threadType: "chat",
+      }),
+    ]);
+    mockedApi.fetchUserProperties.mockResolvedValueOnce({
+      userDetails: JSON.stringify({ name: "Alice Smith" }),
+    });
+    mockedApi.fetchMembers.mockRejectedValueOnce(new Error("Network error"));
+
+    const client = TeamsClient.fromToken("token");
+    const conversations = await client.listConversations();
+
+    expect(conversations[0].topic).toBe("");
+  });
+
   it("should include system streams when excludeSystemStreams is false", async () => {
     mockedApi.fetchConversations.mockResolvedValueOnce([
       makeConversation({ threadType: "chat" }),


### PR DESCRIPTION
Closes #23

## Problem

Group chats without an explicit topic (the default for ad-hoc group chats created in Teams) are invisible to `find_chats`, `find_conversation`, and `list_conversations`. The Teams UI auto-generates a display name from member names (e.g. "Alice, Bob") for these chats, but our code only resolved display names for 1:1 chats.

### Root cause

`resolveOneOnOneDisplayNames()` filtered conversations by `@unq.gbl.spaces` in the ID — the format used by 1:1 chats. Untitled group chats use a different format (`19:{hex}@thread.v2`) and were skipped, leaving their `topic` as an empty string.

This meant:
- `list_conversations` returned them with empty names
- `find_chats` local fallback (topic substring match) never matched
- `find_conversation` topic match never matched
- The only way to access them was by knowing the exact `conversationId`

## Fix

Renamed `resolveOneOnOneDisplayNames` → `resolveUntitledDisplayNames` and extended it to also resolve untitled group chats:

1. Filter for conversations with `@thread.v2` in the ID and no topic
2. Fetch members for each
3. Filter out the current user
4. Join remaining display names with commas (e.g. "Alice, Bob")

This matches the Teams UI behavior.

## Tests

Added 2 new tests:
- Verifies untitled group chat gets member names joined as topic
- Verifies graceful degradation when member fetch fails (topic stays empty)

All 541 tests pass.