### PR TITLE
fix: add profile-based fallback to findOneOnOneConversation

### DIFF
--- a/src/api/middle-tier.ts
+++ b/src/api/middle-tier.ts
@@ -41,7 +41,7 @@ export async function fetchProfiles(
   });
 
   if (!response.ok) {
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       throw new ApiAuthError(
         `Profile resolution authentication failed: ${response.status} ${response.statusText}`,
       );

--- a/src/api/substrate.ts
+++ b/src/api/substrate.ts
@@ -92,7 +92,7 @@ export async function searchPeople(
   });
 
   if (!response.ok) {
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       throw new ApiAuthError(
         `Substrate search authentication failed: ${response.status} ${response.statusText}`,
       );
@@ -176,7 +176,7 @@ export async function searchChats(
   });
 
   if (!response.ok) {
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       throw new ApiAuthError(
         `Substrate search authentication failed: ${response.status} ${response.statusText}`,
       );

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -850,7 +850,9 @@ export class TeamsClient {
       }
 
       // Strategy 1: Substrate search API for people + chat lookup
-      let matchedPersonForCreation: { mri: string; displayName: string } | undefined;
+      let matchedPersonForCreation:
+        | { mri: string; displayName: string }
+        | undefined;
       try {
         const people = await searchPeople(this.token, personName, 5);
         const matchedPerson = people.find((person) =>
@@ -915,6 +917,89 @@ export class TeamsClient {
           authError = error;
         }
         // Substrate unavailable — fall through to profile-based matching
+      }
+
+      // Fallback person discovery: scan group chat members and resolve
+      // via profiles when Substrate search is unavailable.
+      if (!matchedPersonForCreation) {
+        try {
+          const memberMris = new Set<string>();
+
+          // Extract UUIDs from 1:1 conversation IDs
+          for (const conversation of conversations) {
+            const match = conversation.id.match(
+              /19:([a-f0-9-]+)_([a-f0-9-]+)@unq\.gbl\.spaces/i,
+            );
+            if (match) {
+              memberMris.add(`8:orgid:${match[1]}`);
+              memberMris.add(`8:orgid:${match[2]}`);
+            }
+          }
+
+          // Scan group chat members
+          const maxGroupChatsToScan = 10;
+          let groupChatsScanned = 0;
+          for (const conversation of conversations) {
+            if (groupChatsScanned >= maxGroupChatsToScan) break;
+            if (
+              conversation.id.includes("@unq.gbl.spaces") ||
+              conversation.id.startsWith("48:")
+            ) {
+              continue;
+            }
+            if (
+              conversation.threadType === "chat" ||
+              conversation.threadType === "topic"
+            ) {
+              try {
+                const members = await fetchMembers(this.token, conversation.id);
+                for (const member of members) {
+                  if (member.id.startsWith("8:orgid:")) {
+                    memberMris.add(member.id);
+                  }
+                }
+                groupChatsScanned++;
+              } catch {
+                continue;
+              }
+            }
+          }
+
+          if (memberMris.size > 0) {
+            const profiles = await fetchProfiles(this.token, [...memberMris]);
+            const matchedProfile = profiles.find((profile) =>
+              profile.displayName.toLowerCase().includes(targetLower),
+            );
+            if (
+              matchedProfile &&
+              /^8:orgid:[0-9a-f-]+$/i.test(matchedProfile.mri)
+            ) {
+              matchedPersonForCreation = {
+                displayName: matchedProfile.displayName,
+                mri: matchedProfile.mri,
+              };
+
+              // Check if a conversation already exists with this person
+              const personUuid = matchedProfile.mri.replace("8:orgid:", "");
+              const existingConversation = conversations.find(
+                (conversation) =>
+                  conversation.id.includes(personUuid) &&
+                  conversation.threadType === "chat",
+              );
+              if (existingConversation) {
+                return {
+                  conversationId: existingConversation.id,
+                  memberDisplayName: matchedProfile.displayName,
+                };
+              }
+            }
+          }
+        } catch (error) {
+          if (error instanceof ApiAuthError) {
+            authError = error;
+          }
+          // Profile-based fallback failed — continue to other strategies
+        }
       }
 
       // If substrate search identified the person but found no existing chat, create one.
@@ -1112,10 +1197,9 @@ export class TeamsClient {
     // Primary: resolve via profile API
     const displayNameByMri = new Map<string, string>();
     try {
-      const profiles = await fetchProfiles(
-        this.token,
-        [...unresolvedParticipantMris],
-      );
+      const profiles = await fetchProfiles(this.token, [
+        ...unresolvedParticipantMris,
+      ]);
       for (const profile of profiles) {
         if (profile.displayName) {
           displayNameByMri.set(profile.mri, profile.displayName);
@@ -1445,8 +1529,7 @@ export class TeamsClient {
       const needsChatScope = contentParts.some(
         (part) =>
           part.type === "file" &&
-          (part.sharingScope === "chat" ||
-            part.sharingScope === undefined) &&
+          (part.sharingScope === "chat" || part.sharingScope === undefined) &&
           fileSharingScope === "chat",
       );
 
@@ -1606,9 +1689,7 @@ export class TeamsClient {
   /**
    * Resolve emails of all members in a conversation (for user-scoped sharing).
    */
-  private async resolveMemberEmails(
-    conversationId: string,
-  ): Promise<string[]> {
+  private async resolveMemberEmails(conversationId: string): Promise<string[]> {
     const members = await fetchMembers(this.token, conversationId);
     const memberIds = members.map((member) => member.id);
     const profiles = await fetchProfiles(this.token, memberIds);

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -332,6 +332,13 @@ describe("fetchProfiles", () => {
       fetchProfiles(tokenWithBearer, ["8:orgid:user1"]),
     ).rejects.toThrow(ApiAuthError);
   });
+
+  it("should throw ApiAuthError on 403", async () => {
+    mockFetchResponse({}, 403);
+    await expect(
+      fetchProfiles(tokenWithBearer, ["8:orgid:user1"]),
+    ).rejects.toThrow(ApiAuthError);
+  });
 });
 
 describe("postMessage", () => {
@@ -812,7 +819,8 @@ describe("removeReaction", () => {
       ok: false,
       status: 400,
       statusText: "Bad Request",
-      text: () => Promise.resolve("Request body does not contain 'emotions' key"),
+      text: () =>
+        Promise.resolve("Request body does not contain 'emotions' key"),
     });
 
     await expect(

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -570,7 +570,10 @@ describe("findOneOnOneConversation", () => {
   it("should create a new 1:1 conversation when person found via substrate but no existing chat", async () => {
     // No pre-existing 1:1 conversations
     mockedApi.fetchConversations.mockResolvedValue([
-      makeConversation({ id: "19:some-group@thread.v2", threadType: "meeting" }),
+      makeConversation({
+        id: "19:some-group@thread.v2",
+        threadType: "meeting",
+      }),
     ]);
 
     mockedApi.searchPeople.mockResolvedValue([
@@ -617,7 +620,10 @@ describe("findOneOnOneConversation", () => {
     // would abort the if(matchedPerson) block before matchedPersonForCreation was
     // set, causing findOneOnOneConversation to return null instead of creating the chat.
     mockedApi.fetchConversations.mockResolvedValue([
-      makeConversation({ id: "19:some-group@thread.v2", threadType: "meeting" }),
+      makeConversation({
+        id: "19:some-group@thread.v2",
+        threadType: "meeting",
+      }),
     ]);
 
     mockedApi.searchPeople.mockResolvedValue([
@@ -695,7 +701,6 @@ describe("findOneOnOneConversation", () => {
     expect(result!.memberDisplayName).toBe("Alice Smith");
     expect(mockedApi.createOneOnOneConversation).not.toHaveBeenCalled();
   });
-
 
   it("should fall back to profile-based matching when substrate search returns empty", async () => {
     mockedApi.fetchConversations.mockResolvedValue([
@@ -804,6 +809,128 @@ describe("findOneOnOneConversation", () => {
     await expect(
       client.findOneOnOneConversation("Nonexistent Person"),
     ).rejects.toBeInstanceOf(ApiAuthError);
+  });
+
+  it("should find person via group chat member scanning when substrate returns empty", async () => {
+    // No existing 1:1 conversations; only a group chat where Alice is a member
+    mockedApi.fetchConversations.mockResolvedValue([
+      makeConversation({
+        id: "19:group-chat-id@thread.v2",
+        threadType: "chat",
+        topic: "Team Chat",
+      }),
+    ]);
+
+    // Substrate search returns nothing (e.g., substrate API returning 400)
+    mockedApi.searchPeople.mockResolvedValue([]);
+    mockedApi.searchChats.mockResolvedValue([]);
+
+    // Group chat has Alice as a member
+    mockedApi.fetchMembers.mockResolvedValue([
+      {
+        id: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+        displayName: "",
+        role: "member",
+        memberType: "person" as const,
+      },
+      {
+        id: "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+        displayName: "",
+        role: "member",
+        memberType: "person" as const,
+      },
+    ]);
+
+    // Profile resolution finds Alice
+    mockedApi.fetchProfiles.mockResolvedValue([
+      {
+        mri: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+        displayName: "Current User",
+        email: "me@example.com",
+        jobTitle: "",
+        userType: "Member",
+      },
+      {
+        mri: "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+        displayName: "Alice Smith",
+        email: "alice@example.com",
+        jobTitle: "Engineer",
+        userType: "Member",
+      },
+    ]);
+
+    // Should create a new 1:1 conversation since none exists
+    mockedApi.createOneOnOneConversation.mockResolvedValue({
+      id: "19:new-1on1@unq.gbl.spaces",
+    });
+
+    const client = TeamsClient.fromToken(
+      "token",
+      "apac",
+      "bearer",
+      "substrate-token",
+    );
+    const result = await client.findOneOnOneConversation("Alice");
+
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe("19:new-1on1@unq.gbl.spaces");
+    expect(result!.memberDisplayName).toBe("Alice Smith");
+    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+    );
+    expect(mockedApi.fetchMembers).toHaveBeenCalled();
+  });
+
+  it("should find person via group chat members when substrate throws auth error", async () => {
+    // Only a group chat, no 1:1s
+    mockedApi.fetchConversations.mockResolvedValue([
+      makeConversation({
+        id: "19:group-chat@thread.v2",
+        threadType: "chat",
+        topic: "Project Chat",
+      }),
+    ]);
+
+    // Substrate throws auth error (expired token)
+    mockedApi.searchPeople.mockRejectedValue(
+      new ApiAuthError("Substrate search authentication failed: 403 Forbidden"),
+    );
+
+    // Group chat has Alice
+    mockedApi.fetchMembers.mockResolvedValue([
+      {
+        id: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+        displayName: "",
+        role: "member",
+        memberType: "person" as const,
+      },
+    ]);
+
+    // Profile resolution finds Alice
+    mockedApi.fetchProfiles.mockResolvedValue([
+      {
+        mri: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+        displayName: "Alice Smith",
+        email: "alice@example.com",
+        jobTitle: "Engineer",
+        userType: "Member",
+      },
+    ]);
+
+    mockedApi.createOneOnOneConversation.mockResolvedValue({
+      id: "19:new-convo@unq.gbl.spaces",
+    });
+
+    const client = TeamsClient.fromToken("token", "apac", "bearer");
+    const result = await client.findOneOnOneConversation("Alice");
+
+    expect(result).not.toBeNull();
+    expect(result!.memberDisplayName).toBe("Alice Smith");
+    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+    );
   });
 });
 
@@ -1127,9 +1254,7 @@ describe("getMessages", () => {
         "8:orgid:follower-user",
       ]),
     );
-    expect(messages[0].reactions[0].users[0].displayName).toBe(
-      "Reaction User",
-    );
+    expect(messages[0].reactions[0].users[0].displayName).toBe("Reaction User");
     expect(messages[0].followers[0].displayName).toBe("Follower User");
   });
 
@@ -2108,12 +2233,34 @@ describe("sendMessageWithFiles", () => {
 
     // Mock member resolution for default "chat" scope
     mockedApi.fetchMembers.mockResolvedValue([
-      { id: "8:orgid:user-1", displayName: "User One", role: "User", memberType: "person" },
-      { id: "8:orgid:user-2", displayName: "User Two", role: "User", memberType: "person" },
+      {
+        id: "8:orgid:user-1",
+        displayName: "User One",
+        role: "User",
+        memberType: "person",
+      },
+      {
+        id: "8:orgid:user-2",
+        displayName: "User Two",
+        role: "User",
+        memberType: "person",
+      },
     ]);
     mockedApi.fetchProfiles.mockResolvedValue([
-      { mri: "8:orgid:user-1", displayName: "User One", email: "user1@company.com", jobTitle: "", userType: "Member" },
-      { mri: "8:orgid:user-2", displayName: "User Two", email: "user2@company.com", jobTitle: "", userType: "Member" },
+      {
+        mri: "8:orgid:user-1",
+        displayName: "User One",
+        email: "user1@company.com",
+        jobTitle: "",
+        userType: "Member",
+      },
+      {
+        mri: "8:orgid:user-2",
+        displayName: "User Two",
+        email: "user2@company.com",
+        jobTitle: "",
+        userType: "Member",
+      },
     ]);
 
     const uploadResult: attachments.SharePointUploadResult = {
@@ -2193,10 +2340,21 @@ describe("sendMessageWithFiles", () => {
 
     // Mock member resolution for default "chat" scope
     mockedApi.fetchMembers.mockResolvedValue([
-      { id: "8:orgid:user-1", displayName: "User One", role: "User", memberType: "person" },
+      {
+        id: "8:orgid:user-1",
+        displayName: "User One",
+        role: "User",
+        memberType: "person",
+      },
     ]);
     mockedApi.fetchProfiles.mockResolvedValue([
-      { mri: "8:orgid:user-1", displayName: "User One", email: "user1@company.com", jobTitle: "", userType: "Member" },
+      {
+        mri: "8:orgid:user-1",
+        displayName: "User One",
+        email: "user1@company.com",
+        jobTitle: "",
+        userType: "Member",
+      },
     ]);
 
     mockedAttachments.uploadSharePointFile.mockResolvedValue({


### PR DESCRIPTION
## Problem

`findOneOnOneConversation` fails to find people when the Substrate search API is unavailable. The Substrate API has been observed returning `400 Bad Request` (with a generic "The call failed, please try again" message) even with fresh tokens — both old cached and newly acquired tokens produce the same 400 response.

When Substrate returns a non-401/non-500 error (like 400), the code silently returns an empty result set: no `ApiAuthError` is thrown, so `withTokenRefresh` never triggers re-authentication. The function silently falls through all strategies and returns `null`.

Meanwhile, `findPeople` works fine because it has a robust fallback: scanning group chat members via `fetchMembers` and resolving profiles via the middle-tier `fetchProfiles` API (which uses the Bearer token and works correctly).

## Root Cause

1. **Substrate API returns 400** (not 401) for expired or otherwise invalid tokens — treated as empty results `[]`, not as an auth error
2. **`findOneOnOneConversation` lacks a person discovery fallback** — unlike `findPeople`, it doesn't scan group chat members to find the target person when Substrate is unavailable
3. **403 responses weren't treated as auth errors** in `substrate.ts` and `middle-tier.ts`, preventing `withTokenRefresh` from triggering re-auth

## Fix

1. **Added profile-based person discovery fallback to `findOneOnOneConversation`**: when Substrate fails to find the person, the method now scans group chat members (up to 10 group chats) and resolves profiles via the middle-tier API — the same approach that `findPeople` uses successfully
2. **Treat 403 as an auth error** in `substrate.ts` and `middle-tier.ts` (alongside existing 401 handling), enabling `withTokenRefresh` to trigger re-authentication for token expiry scenarios

## Testing

- Added unit test: substrate returns empty -> person found via group chat member scanning -> 1:1 conversation created
- Added unit test: substrate throws `ApiAuthError` (403) -> fallback finds person via profiles -> conversation created
- Added unit test: 403 from profile API throws `ApiAuthError`
- All 544 existing tests continue to pass
- Verified end-to-end: with the fix, a person only reachable via group chat membership is now found by `findOneOnOneConversation`
