### PR TITLE
fix: resolve bot display names and show local time in scheduled messages

### DIFF
--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -439,13 +439,27 @@ export const sendMessage: ActionDefinition = {
         scheduledTime?: string;
       };
     if (scheduled) {
-      return [
+      const lines = [
         "## Message Scheduled",
         "",
         `- **To:** ${conversation}`,
         `- **Message ID:** ${messageId}`,
-        `- **Scheduled for:** ${scheduledTime}`,
-      ].join("\n");
+        `- **Scheduled for (UTC):** ${scheduledTime}`,
+      ];
+      if (scheduledTime) {
+        const date = new Date(scheduledTime);
+        const humanReadable = date.toLocaleString("en-US", {
+          weekday: "long",
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZoneName: "short",
+        });
+        lines.push(`- **Scheduled for (local):** ${humanReadable}`);
+      }
+      return lines.join("\n");
     }
     return [
       "## Message Sent",

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -1629,17 +1629,17 @@ export class TeamsClient {
     return this.withTokenRefresh(async () => {
       const members = await fetchMembers(this.token, conversationId);
 
-      const unresolvedPeople = members.filter(
-        (member) => member.memberType === "person" && !member.displayName,
+      const unresolvedMembers = members.filter(
+        (member) => !member.displayName,
       );
 
-      if (unresolvedPeople.length === 0) {
+      if (unresolvedMembers.length === 0) {
         return members;
       }
 
-      // Primary: resolve via middle-tier profile API (requires bearerToken)
+      // Primary: resolve via middle-tier profile API (supports both people and bots)
       {
-        const mris = unresolvedPeople.map((member) => member.id);
+        const mris = unresolvedMembers.map((member) => member.id);
         try {
           const profiles = await fetchProfiles(this.token, mris);
           const profileLookup = new Map(
@@ -1650,7 +1650,9 @@ export class TeamsClient {
               member.displayName = profileLookup.get(member.id) ?? "";
             }
           }
-          return members;
+          if (members.every((member) => member.displayName)) {
+            return members;
+          }
         } catch {
           // Fall through to message-history fallback
         }
@@ -1658,7 +1660,9 @@ export class TeamsClient {
 
       // Fallback: resolve from message sender names in conversation history
       const unresolvedMris = new Set(
-        unresolvedPeople.map((member) => member.id),
+        unresolvedMembers
+          .filter((member) => !member.displayName)
+          .map((member) => member.id),
       );
       const nameLookup = new Map<string, string>();
       const maxPages = 10;

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -1071,7 +1071,13 @@ describe("send-message", () => {
     const output = action.formatConcise(result);
 
     expect(output).toContain("## Message Scheduled");
-    expect(output).toContain("**Scheduled for:** 2025-07-20T14:30:00.000Z");
+    expect(output).toContain(
+      "**Scheduled for (UTC):** 2025-07-20T14:30:00.000Z",
+    );
+    expect(output).toContain("**Scheduled for (local):**");
+    expect(output).toMatch(
+      /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/,
+    ); // includes day of week
   });
 });
 

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -1650,6 +1650,13 @@ describe("getMembers", () => {
           jobTitle: "",
           userType: "",
         },
+        {
+          mri: "28:bot-id",
+          displayName: "Test Bot",
+          email: "",
+          jobTitle: "",
+          userType: "",
+        },
       ]);
 
       const client = TeamsClient.fromToken("token", "apac", "bearer-token");
@@ -1657,11 +1664,13 @@ describe("getMembers", () => {
 
       expect(members[0].displayName).toBe("Already Named");
       expect(members[1].displayName).toBe("Bob");
-      expect(members[2].displayName).toBe("");
-      // Only user2 should have been sent to fetchProfiles
+      expect(members[2].displayName).toBe("Test Bot");
+      // Both user2 and bot sent to fetchProfiles
       expect(mockedApi.fetchProfiles).toHaveBeenCalledWith(expect.anything(), [
         "8:orgid:user2",
+        "28:bot-id",
       ]);
+      expect(mockedApi.fetchMessagesPage).not.toHaveBeenCalled();
     });
   });
 
@@ -1855,7 +1864,7 @@ describe("getMembers", () => {
     expect(mockedApi.fetchMessagesPage).not.toHaveBeenCalled();
   });
 
-  it("should skip name resolution for bot-only unresolved members", async () => {
+  it("should resolve bot display names via profile API", async () => {
     mockedApi.fetchMembers.mockResolvedValue([
       {
         id: "8:orgid:user1",
@@ -1870,13 +1879,50 @@ describe("getMembers", () => {
         memberType: "bot" as const,
       },
     ]);
+    mockedApi.fetchProfiles.mockResolvedValue([
+      {
+        mri: "28:bot-id",
+        displayName: "Max Mini Bot",
+        email: "",
+        jobTitle: "",
+        userType: "",
+      },
+    ]);
 
-    const client = TeamsClient.fromToken("token");
+    const client = TeamsClient.fromToken("token", "apac", "bearer-token");
     const members = await client.getMembers("conv-id");
 
-    expect(members[1].displayName).toBe("");
-    expect(mockedApi.fetchProfiles).not.toHaveBeenCalled();
+    expect(members[1].displayName).toBe("Max Mini Bot");
+    expect(mockedApi.fetchProfiles).toHaveBeenCalledWith(expect.anything(), [
+      "28:bot-id",
+    ]);
     expect(mockedApi.fetchMessagesPage).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to message history when profile API fails for bot", async () => {
+    mockedApi.fetchMembers.mockResolvedValue([
+      {
+        id: "28:bot-id",
+        displayName: "",
+        role: "User",
+        memberType: "bot" as const,
+      },
+    ]);
+    mockedApi.fetchProfiles.mockRejectedValue(new Error("profile API down"));
+    mockedApi.fetchMessagesPage.mockResolvedValue(
+      makeMessagesPage([
+        makeMessage({
+          senderMri: "28:bot-id",
+          senderDisplayName: "Max Mini",
+        }),
+      ]),
+    );
+
+    const client = TeamsClient.fromToken("token", "apac", "bearer-token");
+    const members = await client.getMembers("conv-id");
+
+    expect(members[0].displayName).toBe("Max Mini");
+    expect(mockedApi.fetchMessagesPage).toHaveBeenCalled();
   });
 
   it("should leave display name empty when no messages match", async () => {


### PR DESCRIPTION
## Changes

### 1. Resolve bot display names via profile API

The `fetchShortProfile` middle-tier API supports bot MRIs (`28:...`) — previously `getMembers()` only sent person MRIs (`8:orgid:...`) for profile resolution, causing bot chats to show as `(untitled)` in conversation listings.

- Send all unresolved MRIs (both people and bots) to the profile API
- Keep the message-history fallback for when the profile API fails entirely

### 2. Show local time in scheduled message confirmation

The scheduled message confirmation now shows the local time alongside the UTC time, so the user/agent can verify the correct delivery time without manual timezone conversion.