### PR TITLE
fix: use correct file extension for downloaded images

### DIFF
--- a/src/actions/file-actions.ts
+++ b/src/actions/file-actions.ts
@@ -8,6 +8,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { extensionFromContentType } from "./mime-utils.js";
 import { type ActionDefinition } from "./formatters.js";
 import {
   conversationParameters,
@@ -102,7 +103,8 @@ export const downloadFileAction: ActionDefinition = {
         true,
       );
 
-      const fileName = `${image.amsObjectId}.jpg`;
+      const extension = extensionFromContentType(contentType);
+      const fileName = `${image.amsObjectId}.${extension}`;
       const outputPath = resolve(join(resolvedOutputDirectory, fileName));
       writeFileSync(outputPath, data);
 

--- a/src/actions/mime-utils.ts
+++ b/src/actions/mime-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * MIME type to file extension mapping utilities.
+ */
+
+const contentTypeToExtension: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+  "image/tiff": "tiff",
+  "image/x-icon": "ico",
+  "image/avif": "avif",
+};
+
+/**
+ * Derive a file extension from a Content-Type header value.
+ *
+ * Falls back to "jpg" when the content type is unrecognised.
+ */
+export function extensionFromContentType(contentType: string): string {
+  const mimeType = contentType.split(";")[0].trim().toLowerCase();
+  return contentTypeToExtension[mimeType] ?? "jpg";
+}

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -1987,7 +1987,7 @@ describe("download-file", () => {
     rmSync(testDirectory, { recursive: true });
   });
 
-  it("should download AMS images", async () => {
+  it("should download AMS images with correct extension for JPEG", async () => {
     const imageData = Buffer.from("fake-image-data");
     const mockClient = createMockClient({
       getMessages: vi.fn().mockResolvedValue([
@@ -2024,6 +2024,42 @@ describe("download-file", () => {
     expect(result[0].contentType).toBe("image/jpeg");
     expect(result[0].data).toEqual(imageData);
     expect(result[0].savedTo).toBeTruthy();
+  });
+
+  it("should use .png extension when image content type is image/png", async () => {
+    const imageData = Buffer.from("fake-png-data");
+    const mockClient = createMockClient({
+      getMessages: vi.fn().mockResolvedValue([
+        makeMessage({
+          id: "msg-1",
+          images: [
+            {
+              amsObjectId: "ams-456",
+              url: "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-456/views/imgo",
+              fullSizeUrl:
+                "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-456/views/imgpsh_fullsize_anim",
+              width: 1024,
+              height: 768,
+              contentPosition: 0,
+            },
+          ],
+        }),
+      ]),
+      downloadImage: vi.fn().mockResolvedValue({
+        data: imageData,
+        contentType: "image/png",
+        size: imageData.length,
+      }),
+    });
+
+    const result = (await downloadFileAction.execute(mockClient, {
+      conversationId: "19:test@thread.space",
+      messageId: "msg-1",
+    })) as import("../../src/actions/file-actions.js").DownloadResult[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fileName).toBe("ams-456.png");
+    expect(result[0].contentType).toBe("image/png");
   });
 
   it("should throw when message not found", async () => {

--- a/tests/unit/mime-utils.test.ts
+++ b/tests/unit/mime-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { extensionFromContentType } from "../../src/actions/mime-utils.js";
+
+describe("extensionFromContentType", () => {
+  it("should return jpg for image/jpeg", () => {
+    expect(extensionFromContentType("image/jpeg")).toBe("jpg");
+  });
+
+  it("should return png for image/png", () => {
+    expect(extensionFromContentType("image/png")).toBe("png");
+  });
+
+  it("should return gif for image/gif", () => {
+    expect(extensionFromContentType("image/gif")).toBe("gif");
+  });
+
+  it("should return webp for image/webp", () => {
+    expect(extensionFromContentType("image/webp")).toBe("webp");
+  });
+
+  it("should handle content type with charset parameter", () => {
+    expect(extensionFromContentType("image/png; charset=utf-8")).toBe("png");
+  });
+
+  it("should be case insensitive", () => {
+    expect(extensionFromContentType("Image/PNG")).toBe("png");
+  });
+
+  it("should fall back to jpg for unknown content types", () => {
+    expect(extensionFromContentType("application/octet-stream")).toBe("jpg");
+  });
+});


### PR DESCRIPTION
Ⓜ

## Summary

Fixes #18 — `download-file` was saving PNG images (and other formats) with a `.jpg` extension.

## Root Cause

In `file-actions.ts`, the inline image download loop hardcoded the filename extension to `.jpg`:
```typescript
const fileName = `${image.amsObjectId}.jpg`;
```

The actual `contentType` from the AMS API response was available but unused for determining the extension.

## Fix

- Added `mime-utils.ts` with `extensionFromContentType()` that maps Content-Type headers to file extensions (`image/png` → `.png`, `image/gif` → `.gif`, etc.)
- Updated inline image download to derive the extension from the response Content-Type
- Falls back to `.jpg` for unrecognised content types

## Tests

- New unit tests for `extensionFromContentType` (7 tests)
- Updated existing download test and added PNG-specific test case
- All 570 unit tests pass
