### PR TITLE
feat: add inline quote/reply support for send and edit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,14 +180,15 @@ TEAMS_EMAIL=you@example.com npm run test:e2e
 
 All actions support two output formats via the `format` parameter:
 
-| Format       | Default | Description |
-| ------------ | ------- | ----------- |
-| `concise`    | Yes     | Light Markdown optimized for actionability. Includes identifiers and decision-critical fields. Nested collections may be summarized with counts/previews. |
-| `detailed`   | No      | Full JSON — the raw result object via `JSON.stringify`. |
+| Format     | Default | Description                                                                                                                                               |
+| ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `concise`  | Yes     | Light Markdown optimized for actionability. Includes identifiers and decision-critical fields. Nested collections may be summarized with counts/previews. |
+| `detailed` | No      | Full JSON — the raw result object via `JSON.stringify`.                                                                                                   |
 
 Each `ActionDefinition` implements a single `formatConcise(result)` method that renders the result as Markdown. The `detailed` format is handled generically by `formatOutput()` — no per-action code needed.
 
 **Concise format rules:**
+
 - Preserve next-action capability without requiring `detailed`.
 - Include stable identifiers that enable follow-up operations (message IDs, conversation IDs, MRI/object IDs when relevant).
 - Include decision-critical fields for the operation, but avoid low-value noise.
@@ -197,29 +198,30 @@ Each `ActionDefinition` implements a single `formatConcise(result)` method that 
 - Use Markdown tables for list data and bullet lists for single-item results.
 
 **Detailed format rule:**
+
 - Always return full JSON with complete structure and values.
 
 ### Concise output contracts by action
 
 Use this table as the review checklist for formatter changes.
 
-| Action | Concise must include | Concise may summarize |
-| ------ | -------------------- | --------------------- |
-| `list-conversations` | Conversation ID, topic, thread type, last-message indicator | Ancillary conversation metadata not needed for selecting a target conversation |
-| `find-conversation` | Conversation ID, thread type, topic | Optional timestamps/nullable fields |
-| `find-one-on-one` | Conversation ID, matched member display name | Search diagnostics |
-| `find-people` | Display name, email, MRI, object ID (if present) | Optional profile attributes |
-| `find-chats` | Thread ID, thread type, member count, match-relevant members | Full member roster |
-| `get-messages` | Message ID, sender, timestamp, message body, quoted message reference IDs | Reactions/followers/mentions as counts or compact lists; attachment internals |
-| `send-message` | Target conversation label, message ID, send/schedule timestamp | Transport-level details |
-| `edit-message` | Conversation label, message ID, edit timestamp | Transport-level details |
-| `delete-message` | Conversation label, message ID | Transport-level details |
-| `add-reaction` | Conversation label, message ID, resolved reaction key | Transport-level details |
-| `remove-reaction` | Conversation label, message ID, resolved reaction key | Transport-level details |
-| `get-members` | Member ID, name, role, member type | Non-actionable profile enrichment |
-| `whoami` | Display name, region | Internal auth metadata |
-| `get-transcript` | Meeting title and readable transcript content | Raw VTT structure unless `rawVtt` is requested |
-| `download-file` | File name, file type, size, content type, saved location | Binary payload internals in Markdown text (binary is returned in content blocks) |
+| Action               | Concise must include                                                      | Concise may summarize                                                            |
+| -------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `list-conversations` | Conversation ID, topic, thread type, last-message indicator               | Ancillary conversation metadata not needed for selecting a target conversation   |
+| `find-conversation`  | Conversation ID, thread type, topic                                       | Optional timestamps/nullable fields                                              |
+| `find-one-on-one`    | Conversation ID, matched member display name                              | Search diagnostics                                                               |
+| `find-people`        | Display name, email, MRI, object ID (if present)                          | Optional profile attributes                                                      |
+| `find-chats`         | Thread ID, thread type, member count, match-relevant members              | Full member roster                                                               |
+| `get-messages`       | Message ID, sender, timestamp, message body, quoted message reference IDs | Reactions/followers/mentions as counts or compact lists; attachment internals    |
+| `send-message`       | Target conversation label, message ID, send/schedule timestamp            | Transport-level details                                                          |
+| `edit-message`       | Conversation label, message ID, edit timestamp                            | Transport-level details                                                          |
+| `delete-message`     | Conversation label, message ID                                            | Transport-level details                                                          |
+| `add-reaction`       | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                          |
+| `remove-reaction`    | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                          |
+| `get-members`        | Member ID, name, role, member type                                        | Non-actionable profile enrichment                                                |
+| `whoami`             | Display name, region                                                      | Internal auth metadata                                                           |
+| `get-transcript`     | Meeting title and readable transcript content                             | Raw VTT structure unless `rawVtt` is requested                                   |
+| `download-file`      | File name, file type, size, content type, saved location                  | Binary payload internals in Markdown text (binary is returned in content blocks) |
 
 This design follows [Anthropic's tool design guidance](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/best-practices) — a `response_format` enum with concise (~1/3 tokens) and detailed (full data) modes.
 
@@ -264,11 +266,11 @@ Teams returns several system streams alongside real conversations (annotations, 
 
 When enabled, every tool call is appended as a JSON line to a local JSONL file:
 
-| Platform | Path |
-| --- | --- |
-| macOS | `~/Library/Application Support/teams-api/telemetry.jsonl` |
-| Linux | `$XDG_DATA_HOME/teams-api/telemetry.jsonl` (default: `~/.local/share/teams-api/telemetry.jsonl`) |
-| Windows | `%APPDATA%\teams-api\telemetry.jsonl` |
+| Platform | Path                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------ |
+| macOS    | `~/Library/Application Support/teams-api/telemetry.jsonl`                                        |
+| Linux    | `$XDG_DATA_HOME/teams-api/telemetry.jsonl` (default: `~/.local/share/teams-api/telemetry.jsonl`) |
+| Windows  | `%APPDATA%\teams-api\telemetry.jsonl`                                                            |
 
 Each record contains: tool name, format, full input parameters, raw API result, formatted output string, duration (ms), and timestamp. Auth events and errors (with full stack traces) are also recorded.
 

--- a/README.md
+++ b/README.md
@@ -192,15 +192,15 @@ Manual token usage, debug-session auth, and programmatic Node.js usage are cover
 
 ## Platform support
 
-| Feature                | macOS          | Windows / Linux |
-| ---------------------- | -------------- | --------------- |
-| **Interactive login**  | Full support   | Full support    |
-| **Auto-login (FIDO2)** | Full support   | Not supported   |
-| **Debug session**      | Full support   | Full support    |
-| **Direct token**       | Full support   | Full support    |
+| Feature                | macOS          | Windows / Linux                   |
+| ---------------------- | -------------- | --------------------------------- |
+| **Interactive login**  | Full support   | Full support                      |
+| **Auto-login (FIDO2)** | Full support   | Not supported                     |
+| **Debug session**      | Full support   | Full support                      |
+| **Direct token**       | Full support   | Full support                      |
 | **Token caching**      | macOS Keychain | Windows DPAPI / Linux secret-tool |
-| **CLI & MCP server**   | Full support   | Full support    |
-| **Programmatic API**   | Full support   | Full support    |
+| **CLI & MCP server**   | Full support   | Full support                      |
+| **Programmatic API**   | Full support   | Full support                      |
 
 > [!NOTE]
 > **Windows Defender false positive:** Older versions of this package used inline PowerShell to call the Windows DPAPI — a pattern that Windows Defender flags as ransomware-like behavior. This has been replaced with native Windows Credential Manager storage via [keytar](https://github.com/atom/node-keytar). If you hit issues on an older version, upgrade and re-run `teams-api auth --login`. See [SECURITY.md](./SECURITY.md) for details.
@@ -305,8 +305,8 @@ The examples below use `teams-api` for readability. If you are not installing gl
 | `--substrate-token <token>` | Optional Substrate bearer token (advanced/manual)                                |
 | `--debug-port <port>`       | Chrome debug port (default: 9222)                                                |
 | `--region <region>`         | API region override. Auto-detected for login/debug auth; required with `--token` |
-| `--format <format>`         | Output format: concise, detailed                                             |
-| `--output <file>`           | Export output to file (default format: concise)                              |
+| `--format <format>`         | Output format: concise, detailed                                                 |
+| `--output <file>`           | Export output to file (default format: concise)                                  |
 
 ### Examples
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ On Windows, the previous token storage implementation spawned a PowerShell proce
 powershell -Command "Add-Type -AssemblyName System.Security; ... ProtectedData::Protect(...) ..."
 ```
 
-This is one of the most reliable behavioral signatures in Windows Defender's heuristics for ransomware and credential-theft malware — spawning PowerShell, loading a crypto assembly, and encrypting arbitrary binary data inline. Defender flags the *behavior*, not the intent.
+This is one of the most reliable behavioral signatures in Windows Defender's heuristics for ransomware and credential-theft malware — spawning PowerShell, loading a crypto assembly, and encrypting arbitrary binary data inline. Defender flags the _behavior_, not the intent.
 
 ### What we do instead
 
@@ -24,10 +24,10 @@ Tokens are now stored using [keytar](https://github.com/atom/node-keytar), which
 
 ### Token storage by platform
 
-| Platform | Storage |
-|----------|---------|
-| macOS    | Keychain (via `security` CLI) |
-| Windows  | Windows Credential Manager (via keytar / wincred) |
+| Platform | Storage                                                              |
+| -------- | -------------------------------------------------------------------- |
+| macOS    | Keychain (via `security` CLI)                                        |
+| Windows  | Windows Credential Manager (via keytar / wincred)                    |
 | Linux    | `secret-tool` (libsecret) or `~/.config/teams-api/` with 0o600 perms |
 
 ### Migrating from the old DPAPI storage

--- a/src/actions/conversation-actions.ts
+++ b/src/actions/conversation-actions.ts
@@ -34,8 +34,7 @@ export const listConversations: ActionDefinition = {
     lines.push("|---|-------|------|----|--------------|");
     for (let i = 0; i < conversations.length; i++) {
       const conversation = conversations[i];
-      const lastMessage =
-        conversation.lastMessageTime?.slice(0, 10) ?? "";
+      const lastMessage = conversation.lastMessageTime?.slice(0, 10) ?? "";
       const topic = conversation.topic || "(untitled)";
       lines.push(
         `| ${i} | ${topic} | ${conversation.threadType} | ${conversation.id} | ${lastMessage} |`,
@@ -75,7 +74,9 @@ export const findConversation: ActionDefinition = {
       `- **Type:** ${conversation.threadType}`,
     ];
     if (conversation.lastMessageTime) {
-      lines.push(`- **Last message:** ${conversation.lastMessageTime.slice(0, 10)}`);
+      lines.push(
+        `- **Last message:** ${conversation.lastMessageTime.slice(0, 10)}`,
+      );
     }
     return lines.join("\n");
   },

--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -231,7 +231,10 @@ export const getMessages: ActionDefinition = {
       if (quote && message.quotedMessageId) {
         const quotedSender =
           senderLookup.get(message.quotedMessageId) ?? "unknown";
-        lines.push(`> **[replying to ${quotedSender} (${message.quotedMessageId})]:** ${quote}`, "");
+        lines.push(
+          `> **[replying to ${quotedSender} (${message.quotedMessageId})]:** ${quote}`,
+          "",
+        );
       }
 
       lines.push(body, "");
@@ -261,7 +264,9 @@ export const getMessages: ActionDefinition = {
         metadata.push(attachmentSummary);
       }
       if (message.editTime) {
-        metadata.push(`Edited: ${message.editTime.slice(0, 19).replace("T", " ")}`);
+        metadata.push(
+          `Edited: ${message.editTime.slice(0, 19).replace("T", " ")}`,
+        );
       }
       if (metadata.length > 0) {
         lines.push(metadata.join(" | "), "");
@@ -331,7 +336,7 @@ export const sendMessage: ActionDefinition = {
       name: "fileSharingScope",
       type: "string",
       description:
-        'Sharing scope for uploaded files: ' +
+        "Sharing scope for uploaded files: " +
         '"chat" (default — share with chat participants), ' +
         '"organization" (anyone in the org with the link), ' +
         '"none" (no sharing — only the uploader can access). ' +
@@ -352,10 +357,18 @@ export const sendMessage: ActionDefinition = {
       description:
         "Schedule the message to be sent at a future time. " +
         "Accepts an ISO 8601 timestamp with an explicit timezone designator " +
-        '(e.g. 2025-01-15T14:30:00Z, 2025-01-15T14:30:00+05:30). Bare local ' +
+        "(e.g. 2025-01-15T14:30:00Z, 2025-01-15T14:30:00+05:30). Bare local " +
         "datetimes without a timezone (e.g. 2025-01-15T14:30:00) are rejected " +
         "because they are ambiguous. " +
         "Cannot be combined with --image or --file attachments.",
+      required: false,
+    },
+    {
+      name: "quoteMessageId",
+      type: "string",
+      description:
+        "Message ID to quote (inline reply). The referenced message's content " +
+        "is automatically fetched and included as a blockquote above your message.",
       required: false,
     },
   ],
@@ -373,6 +386,7 @@ export const sendMessage: ActionDefinition = {
     const filePaths = (parameters.file as string[] | undefined) ?? [];
     const scheduleAtRaw = parameters.scheduleAt as string | undefined;
     const subject = parameters.subject as string | undefined;
+    const quoteMessageId = parameters.quoteMessageId as string | undefined;
 
     if (!content && imagePaths.length === 0 && filePaths.length === 0) {
       throw new Error(
@@ -448,6 +462,7 @@ export const sendMessage: ActionDefinition = {
       messageFormat,
       [],
       subject,
+      quoteMessageId,
     );
     return { ...result, conversation: label };
   },
@@ -525,6 +540,14 @@ export const editMessageAction: ActionDefinition = {
       required: false,
       default: "markdown",
     },
+    {
+      name: "quoteMessageId",
+      type: "string",
+      description:
+        "Message ID to quote (inline reply). The referenced message's content " +
+        "is automatically fetched and included as a blockquote above your message.",
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     const { conversationId, label } = await resolveConversationId(
@@ -535,11 +558,13 @@ export const editMessageAction: ActionDefinition = {
     const content = parameters.content as string;
     const messageFormat =
       (parameters.messageFormat as MessageFormat | undefined) ?? "markdown";
+    const quoteMessageId = parameters.quoteMessageId as string | undefined;
     const result = await client.editMessage(
       conversationId,
       messageId,
       content,
       messageFormat,
+      quoteMessageId,
     );
     return { ...result, conversation: label };
   },
@@ -624,7 +649,7 @@ export const addReactionAction: ActionDefinition = {
       description:
         'Reaction name — standard ("like", "heart", "laugh", "surprised", "angry", "sad") ' +
         'or any Teams emoji shortcut ("horse", "fire", "clap"). ' +
-        'Auto-resolved to the Teams emoji ID.',
+        "Auto-resolved to the Teams emoji ID.",
       required: true,
     },
   ],
@@ -681,7 +706,7 @@ export const removeReactionAction: ActionDefinition = {
       type: "string",
       description:
         'Reaction name or emoji ID to remove (e.g. "like", "heart", "horse", "1f40e_horse"). ' +
-        'Auto-resolved to the Teams emoji ID.',
+        "Auto-resolved to the Teams emoji ID.",
       required: true,
     },
   ],

--- a/src/actions/utility-actions.ts
+++ b/src/actions/utility-actions.ts
@@ -43,7 +43,9 @@ export const getMembers: ActionDefinition = {
       lines.push("|------|------|------|----|");
       for (const member of people) {
         const name = member.displayName || "(unknown)";
-        lines.push(`| ${name} | ${member.role} | ${member.memberType} | ${member.id} |`);
+        lines.push(
+          `| ${name} | ${member.role} | ${member.memberType} | ${member.id} |`,
+        );
       }
     }
     if (bots.length > 0) {

--- a/src/api/chat-service.ts
+++ b/src/api/chat-service.ts
@@ -165,6 +165,20 @@ export async function fetchMembers(
 }
 
 /**
+ * Escape plain-text content for safe inclusion in HTML.
+ *
+ * When a quote is prepended to a plain-text message, the text must be
+ * escaped and wrapped so it renders correctly alongside the HTML blockquote.
+ */
+function escapeHtmlContent(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
  * Convert content to the appropriate format for the Teams API.
  *
  * - "text": sent as-is with messagetype "Text"
@@ -216,14 +230,24 @@ export async function postMessage(
   amsReferences: string[] = [],
   filesJson?: string,
   subject?: string,
+  quoteHtml?: string,
 ): Promise<SentMessage> {
   const url = `${chatServiceBase(token.region)}/users/ME/conversations/${encodeURIComponent(conversationId)}/messages`;
 
   const clientMessageId = String(Date.now());
-  const { resolvedContent, messagetype, contenttype } = resolveMessageContent(
+  let { resolvedContent, messagetype, contenttype } = resolveMessageContent(
     content,
     format,
   );
+
+  if (quoteHtml) {
+    if (messagetype !== "RichText/Html") {
+      // Wrap plain-text content in a paragraph so it renders correctly as HTML
+      resolvedContent = escapeHtmlContent(resolvedContent);
+    }
+    resolvedContent = quoteHtml + resolvedContent;
+    messagetype = "RichText/Html";
+  }
 
   const body: Record<string, unknown> = {
     content: resolvedContent,
@@ -288,13 +312,22 @@ export async function editMessage(
   content: string,
   senderDisplayName: string,
   format: MessageFormat = "markdown",
+  quoteHtml?: string,
 ): Promise<EditedMessage> {
   const url = `${chatServiceBase(token.region)}/users/ME/conversations/${encodeURIComponent(conversationId)}/messages/${encodeURIComponent(messageId)}`;
 
-  const { resolvedContent, messagetype, contenttype } = resolveMessageContent(
+  let { resolvedContent, messagetype, contenttype } = resolveMessageContent(
     content,
     format,
   );
+
+  if (quoteHtml) {
+    if (messagetype !== "RichText/Html") {
+      resolvedContent = escapeHtmlContent(resolvedContent);
+    }
+    resolvedContent = quoteHtml + resolvedContent;
+    messagetype = "RichText/Html";
+  }
 
   const body = {
     content: resolvedContent,
@@ -606,7 +639,9 @@ export async function createOneOnOneConversation(
 
   const data = (await response.json()) as { id?: string };
   if (!data.id) {
-    throw new Error("No conversation ID returned when creating 1:1 conversation");
+    throw new Error(
+      "No conversation ID returned when creating 1:1 conversation",
+    );
   }
   return { id: data.id };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,10 +54,7 @@ function addAuthOptions(command: Command): Command {
       "--login",
       "Interactive browser login (all platforms, no FIDO2 needed)",
     )
-    .option(
-      "--debug",
-      "Use Chrome debug session for token capture",
-    )
+    .option("--debug", "Use Chrome debug session for token capture")
     .option(
       "--email <email>",
       "Corporate email (required with --auto, optional with --login)",

--- a/src/credential-store.ts
+++ b/src/credential-store.ts
@@ -52,7 +52,14 @@ class KeychainStore implements CredentialStore {
     try {
       return execFileSync(
         "security",
-        ["find-generic-password", "-a", account, "-s", CREDENTIAL_SERVICE, "-w"],
+        [
+          "find-generic-password",
+          "-a",
+          account,
+          "-s",
+          CREDENTIAL_SERVICE,
+          "-w",
+        ],
         { encoding: "utf-8" },
       ).trim();
     } catch {
@@ -129,7 +136,11 @@ class WinCredStore implements CredentialStore {
     }
 
     // Primary entry stores the chunk count
-    await kt.setPassword(CREDENTIAL_SERVICE, key, `${CHUNK_MARKER}${chunks.length}`);
+    await kt.setPassword(
+      CREDENTIAL_SERVICE,
+      key,
+      `${CHUNK_MARKER}${chunks.length}`,
+    );
     for (let i = 0; i < chunks.length; i++) {
       await kt.setPassword(CREDENTIAL_SERVICE, `${key}:${i}`, chunks[i]);
     }
@@ -193,7 +204,8 @@ class WinCredStore implements CredentialStore {
 
 function getLinuxStorePath(): string {
   const configDir =
-    process.env.XDG_CONFIG_HOME ?? join(process.env.HOME ?? homedir(), ".config");
+    process.env.XDG_CONFIG_HOME ??
+    join(process.env.HOME ?? homedir(), ".config");
   return join(configDir, "teams-api");
 }
 

--- a/src/emoji-map.ts
+++ b/src/emoji-map.ts
@@ -116,8 +116,9 @@ async function fetchCurrentVersion(): Promise<string | null> {
         continue;
       }
       const responseText = await response.text();
-      const emoticonAssetVersionMatch =
-        /"emoticonAssetVersion":"([^"]+)"/.exec(responseText);
+      const emoticonAssetVersionMatch = /"emoticonAssetVersion":"([^"]+)"/.exec(
+        responseText,
+      );
       if (!emoticonAssetVersionMatch) {
         console.warn(
           `[emoji-map] emoticonAssetVersion not found for app version ${appVersionCandidate}, trying next candidate`,
@@ -238,4 +239,3 @@ export function resolveReactionKey(input: string): string {
   // Map not loaded — fall back to lowercasing (standard reactions still work)
   return input.toLowerCase();
 }
-

--- a/src/html-utils.ts
+++ b/src/html-utils.ts
@@ -1,8 +1,8 @@
 /**
- * Shared HTML entity decoding utilities.
+ * Shared HTML utilities for entity decoding, escaping, and Teams markup.
  *
- * Used by both the VTT transcript parser and the action formatters
- * to convert HTML entities back to plain text.
+ * Used by both the VTT transcript parser, the action formatters,
+ * and the quote/inline-reply builder.
  */
 
 /** Decode common HTML entities to plain text. */
@@ -17,4 +17,44 @@ export function decodeHtmlEntities(text: string): string {
     .replace(/&#(\d+);/g, (_, code: string) =>
       String.fromCharCode(Number(code)),
     );
+}
+
+/** Escape characters that are special in HTML to prevent injection. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Build a Teams inline-quote blockquote HTML element.
+ *
+ * Teams represents inline quotes using a `<blockquote>` with Skype schema
+ * microdata attributes. This is the format Teams Desktop/Web produces when
+ * a user right-clicks a message and selects "Reply".
+ *
+ * @param messageId  - The ID of the quoted message (OriginalArrivalTime).
+ * @param senderMri  - Full MRI of the quoted message sender (e.g. "8:orgid:{uuid}").
+ * @param senderDisplayName - Display name of the quoted message sender.
+ * @param previewText - Plain-text preview of the quoted message content.
+ */
+export function buildQuoteHtml(options: {
+  messageId: string;
+  senderMri: string;
+  senderDisplayName: string;
+  previewText: string;
+}): string {
+  const truncatedPreview =
+    options.previewText.length > 200
+      ? `${options.previewText.slice(0, 197)}...`
+      : options.previewText;
+
+  return (
+    `<blockquote itemscope="" itemtype="http://schema.skype.com/Reply" itemid="${escapeHtml(options.messageId)}">` +
+    `<strong itemprop="mri" itemid="${escapeHtml(options.senderMri)}">${escapeHtml(options.senderDisplayName)}</strong>` +
+    `<p itemprop="preview">${escapeHtml(truncatedPreview)}</p>` +
+    `</blockquote>`
+  );
 }

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -78,6 +78,8 @@ import { resolveReactionKey, initializeEmojiMap } from "./emoji-map.js";
 import { fetchProfiles } from "./api/middle-tier.js";
 import { searchPeople, searchChats } from "./api/substrate.js";
 import { fetchTranscript } from "./api/transcripts.js";
+import { buildQuoteHtml } from "./html-utils.js";
+import { cleanContent } from "./actions/formatters.js";
 import {
   fetchAmsImage,
   fetchSharePointFile,
@@ -1314,9 +1316,13 @@ export class TeamsClient {
     format: MessageFormat = "markdown",
     amsReferences: string[] = [],
     subject?: string,
+    quoteMessageId?: string,
   ): Promise<SentMessage> {
     return this.withTokenRefresh(async () => {
       const displayName = await this.getCurrentUserDisplayName();
+      const quoteHtml = quoteMessageId
+        ? await this.buildQuoteHtmlForMessage(conversationId, quoteMessageId)
+        : undefined;
       return postMessage(
         this.token,
         conversationId,
@@ -1326,6 +1332,7 @@ export class TeamsClient {
         amsReferences,
         undefined,
         subject,
+        quoteHtml,
       );
     });
   }
@@ -1343,9 +1350,13 @@ export class TeamsClient {
     messageId: string,
     content: string,
     format: MessageFormat = "markdown",
+    quoteMessageId?: string,
   ): Promise<EditedMessage> {
     return this.withTokenRefresh(async () => {
       const displayName = await this.getCurrentUserDisplayName();
+      const quoteHtml = quoteMessageId
+        ? await this.buildQuoteHtmlForMessage(conversationId, quoteMessageId)
+        : undefined;
       return editMessage(
         this.token,
         conversationId,
@@ -1353,7 +1364,35 @@ export class TeamsClient {
         content,
         displayName,
         format,
+        quoteHtml,
       );
+    });
+  }
+
+  /**
+   * Look up a message in a conversation and build quote HTML for it.
+   *
+   * Fetches up to 200 recent messages (newest-first) to find the target.
+   * Since quotes typically reference recent messages, this handles the
+   * common case efficiently with a single page fetch.
+   */
+  private async buildQuoteHtmlForMessage(
+    conversationId: string,
+    quoteMessageId: string,
+  ): Promise<string> {
+    const messages = await this.getMessages(conversationId, { limit: 200 });
+    const target = messages.find((message) => message.id === quoteMessageId);
+    if (!target) {
+      throw new Error(
+        `Could not find message ${quoteMessageId} in conversation ${conversationId} (searched 200 most recent messages)`,
+      );
+    }
+    const previewText = cleanContent(target.content);
+    return buildQuoteHtml({
+      messageId: quoteMessageId,
+      senderMri: target.senderMri,
+      senderDisplayName: target.senderDisplayName || "(unknown)",
+      previewText,
     });
   }
 
@@ -1648,9 +1687,7 @@ export class TeamsClient {
     return this.withTokenRefresh(async () => {
       const members = await fetchMembers(this.token, conversationId);
 
-      const unresolvedMembers = members.filter(
-        (member) => !member.displayName,
-      );
+      const unresolvedMembers = members.filter((member) => !member.displayName);
 
       if (unresolvedMembers.length === 0) {
         return members;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -144,7 +144,11 @@ export function recordToolError(opts: {
     parameters: opts.parameters,
     error:
       opts.error instanceof Error
-        ? { name: opts.error.name, message: opts.error.message, stack: opts.error.stack }
+        ? {
+            name: opts.error.name,
+            message: opts.error.message,
+            stack: opts.error.stack,
+          }
         : String(opts.error),
   });
 }

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -25,7 +25,10 @@ interface StoredToken {
 
 const store = createCredentialStore();
 
-export async function saveToken(email: string, token: TeamsToken): Promise<void> {
+export async function saveToken(
+  email: string,
+  token: TeamsToken,
+): Promise<void> {
   const storedToken: StoredToken = {
     skypeToken: token.skypeToken,
     region: token.region,

--- a/tests/e2e/windows-credential-store.test.ts
+++ b/tests/e2e/windows-credential-store.test.ts
@@ -86,40 +86,36 @@ describe.skipIf(!shouldRun)(
   },
 );
 
-describe.skipIf(!shouldRun)(
-  "Windows Token Store",
-  { timeout: 30_000 },
-  () => {
-    const tokenKey = "teams-api-e2e-token";
+describe.skipIf(!shouldRun)("Windows Token Store", { timeout: 30_000 }, () => {
+  const tokenKey = "teams-api-e2e-token";
 
-    afterAll(async () => {
-      await clearToken(tokenKey).catch(() => {});
-    });
+  afterAll(async () => {
+    await clearToken(tokenKey).catch(() => {});
+  });
 
-    it("should save and load a realistic token payload", async () => {
-      const token = {
-        skypeToken: "sk_" + "a".repeat(1500),
-        region: "apac",
-        bearerToken: "bt_" + "b".repeat(1500),
-        substrateToken: "st_" + "c".repeat(500),
-      };
-      await saveToken(tokenKey, token as any);
-      const loaded = await loadToken(tokenKey);
+  it("should save and load a realistic token payload", async () => {
+    const token = {
+      skypeToken: "sk_" + "a".repeat(1500),
+      region: "apac",
+      bearerToken: "bt_" + "b".repeat(1500),
+      substrateToken: "st_" + "c".repeat(500),
+    };
+    await saveToken(tokenKey, token as any);
+    const loaded = await loadToken(tokenKey);
 
-      expect(loaded).not.toBeNull();
-      expect(loaded!.skypeToken).toBe(token.skypeToken);
-      expect(loaded!.bearerToken).toBe(token.bearerToken);
-      expect(loaded!.substrateToken).toBe(token.substrateToken);
-      expect(loaded!.region).toBe(token.region);
-    });
+    expect(loaded).not.toBeNull();
+    expect(loaded!.skypeToken).toBe(token.skypeToken);
+    expect(loaded!.bearerToken).toBe(token.bearerToken);
+    expect(loaded!.substrateToken).toBe(token.substrateToken);
+    expect(loaded!.region).toBe(token.region);
+  });
 
-    it("should clear a saved token", async () => {
-      await saveToken(tokenKey, {
-        skypeToken: "temp",
-        region: "amer",
-      } as any);
-      await clearToken(tokenKey);
-      expect(await loadToken(tokenKey)).toBeNull();
-    });
-  },
-);
+  it("should clear a saved token", async () => {
+    await saveToken(tokenKey, {
+      skypeToken: "temp",
+      region: "amer",
+    } as any);
+    await clearToken(tokenKey);
+    expect(await loadToken(tokenKey)).toBeNull();
+  });
+});

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -694,9 +694,9 @@ describe("get-messages", () => {
   it("should append ;messageid= to conversation ID when messageId is provided", async () => {
     const messages = [makeMessage()];
     const client = createMockClient({
-      findConversation: vi.fn().mockResolvedValue(
-        makeConversation({ id: "19:channel@thread.tacv2" }),
-      ),
+      findConversation: vi
+        .fn()
+        .mockResolvedValue(makeConversation({ id: "19:channel@thread.tacv2" })),
       getMessages: vi.fn().mockResolvedValue(messages),
     });
 
@@ -822,6 +822,7 @@ describe("send-message", () => {
       "markdown",
       [],
       undefined,
+      undefined,
     );
     expect(result.messageId).toBe("1773000000000");
     expect(result.conversation).toBe("Design Review");
@@ -848,6 +849,7 @@ describe("send-message", () => {
       "text",
       [],
       undefined,
+      undefined,
     );
   });
 
@@ -871,6 +873,7 @@ describe("send-message", () => {
       "<b>Bold</b>",
       "html",
       [],
+      undefined,
       undefined,
     );
   });
@@ -896,11 +899,14 @@ describe("send-message", () => {
       "markdown",
       [],
       "My Post Title",
+      undefined,
     );
   });
 
   it("should forward --subject to scheduleMessage", async () => {
-    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1_000).toISOString();
+    const futureDate = new Date(
+      Date.now() + 24 * 60 * 60 * 1_000,
+    ).toISOString();
     const scheduledMessage: ScheduledMessage = {
       messageId: "1753021800000",
       arrivalTime: 1753021800000,
@@ -955,9 +961,14 @@ describe("send-message", () => {
       arrivalTime: 1774999999999,
     };
     const client = createMockClient({
-      findConversation: vi.fn().mockResolvedValue(
-        makeConversation({ id: "19:channel@thread.tacv2", topic: "Dev Channel" }),
-      ),
+      findConversation: vi
+        .fn()
+        .mockResolvedValue(
+          makeConversation({
+            id: "19:channel@thread.tacv2",
+            topic: "Dev Channel",
+          }),
+        ),
       sendMessage: vi.fn().mockResolvedValue(sentMessage),
     });
 
@@ -972,6 +983,7 @@ describe("send-message", () => {
       "Thread reply!",
       "markdown",
       [],
+      undefined,
       undefined,
     );
   });
@@ -1185,6 +1197,7 @@ describe("edit-message", () => {
       "msg-123",
       "Updated content",
       "markdown",
+      undefined,
     );
     expect(result.messageId).toBe("msg-123");
     expect(result.conversation).toBe("Design Review");
@@ -1211,6 +1224,7 @@ describe("edit-message", () => {
       "msg-text",
       "plain text update",
       "text",
+      undefined,
     );
   });
 
@@ -1235,6 +1249,7 @@ describe("edit-message", () => {
       "msg-html",
       "<b>Bold edit</b>",
       "html",
+      undefined,
     );
   });
 
@@ -1674,7 +1689,11 @@ describe("formatOutput", () => {
   });
 
   it("should handle null result in detailed format", () => {
-    const output = formatOutput(getAction("find-conversation"), null, "detailed");
+    const output = formatOutput(
+      getAction("find-conversation"),
+      null,
+      "detailed",
+    );
     expect(output).toBe("null");
   });
 });

--- a/tests/unit/attachments.test.ts
+++ b/tests/unit/attachments.test.ts
@@ -463,7 +463,8 @@ describe("uploadSharePointFile", () => {
           Promise.resolve({
             shareId: "share-link-id",
             link: {
-              webUrl: "https://company-my.sharepoint.com/:t:/p/user_name/shared-link",
+              webUrl:
+                "https://company-my.sharepoint.com/:t:/p/user_name/shared-link",
             },
           }),
       });

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -122,7 +122,7 @@ describe.runIf(process.platform === "win32")(
         await import("../../src/credential-store.js");
       const store = createCredentialStore();
 
-      const specialData = 'quotes"and\'backslash\\newline\ntab\t${}`template`';
+      const specialData = "quotes\"and'backslash\\newline\ntab\t${}`template`";
       await store.save(testAccount, specialData);
       const loaded = await store.load(testAccount);
 

--- a/tests/unit/emoji-map.test.ts
+++ b/tests/unit/emoji-map.test.ts
@@ -51,9 +51,15 @@ function mockFetchSuccess(): void {
     "fetch",
     vi.fn().mockImplementation((url: string) => {
       if (url.includes("config.teams.microsoft.com")) {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(TEST_ECS_RESPONSE) });
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(TEST_ECS_RESPONSE),
+        });
       }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(testCatalog),
+      });
     }),
   );
 }
@@ -62,10 +68,7 @@ function mockFetchSuccess(): void {
  * Stub fetch to fail for all requests.
  */
 function mockFetchFailure(): void {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue({ ok: false, status: 404 }),
-  );
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
 }
 
 /**
@@ -78,7 +81,10 @@ function mockFetchEcsFailCdnSuccess(): void {
       if (url.includes("config.teams.microsoft.com")) {
         return Promise.resolve({ ok: false, status: 503 });
       }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(testCatalog),
+      });
     }),
   );
 }
@@ -97,8 +103,12 @@ describe("initializeEmojiMap", () => {
     mockFetchSuccess();
     await initializeEmojiMap();
     const calls = vi.mocked(fetch).mock.calls.map((c) => c[0] as string);
-    expect(calls.some((u) => u.includes("config.teams.microsoft.com"))).toBe(true);
-    expect(calls.some((u) => u.includes("statics.teams.cdn.office.net"))).toBe(true);
+    expect(calls.some((u) => u.includes("config.teams.microsoft.com"))).toBe(
+      true,
+    );
+    expect(calls.some((u) => u.includes("statics.teams.cdn.office.net"))).toBe(
+      true,
+    );
     // CDN URL uses the ECS-resolved version hash
     expect(calls.some((u) => u.includes(TEST_ECS_VERSION))).toBe(true);
   });
@@ -117,20 +127,28 @@ describe("initializeEmojiMap", () => {
       "fetch",
       vi.fn().mockImplementation((url: string) => {
         if (url.includes("config.teams.microsoft.com")) {
-          return Promise.resolve({ ok: true, text: () => Promise.resolve(TEST_ECS_RESPONSE) });
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(TEST_ECS_RESPONSE),
+          });
         }
         if (url.includes(TEST_ECS_VERSION)) {
           return Promise.resolve({ ok: false, status: 404 });
         }
         // Fallback CDN versions succeed
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(testCatalog),
+        });
       }),
     );
     await initializeEmojiMap();
     expect(resolveReactionKey("horse")).toBe("1f40e_horse");
     const calls = vi.mocked(fetch).mock.calls.map((c) => c[0] as string);
     // ECS call, ECS-version CDN call (404), then a fallback version CDN call
-    expect(calls.filter((u) => u.includes("statics.teams.cdn.office.net")).length).toBeGreaterThanOrEqual(2);
+    expect(
+      calls.filter((u) => u.includes("statics.teams.cdn.office.net")).length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("validates the ECS version format and falls back on malformed values", async () => {
@@ -139,16 +157,28 @@ describe("initializeEmojiMap", () => {
       "fetch",
       vi.fn().mockImplementation((url: string) => {
         if (url.includes("config.teams.microsoft.com")) {
-          return Promise.resolve({ ok: true, text: () => Promise.resolve(malformedEcsResponse) });
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(malformedEcsResponse),
+          });
         }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(testCatalog) });
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(testCatalog),
+        });
       }),
     );
     await initializeEmojiMap();
     // Should still succeed via fallback versions
     expect(resolveReactionKey("horse")).toBe("1f40e_horse");
-    const warnings = vi.mocked(console.warn).mock.calls.map((c) => c[0] as string);
-    expect(warnings.some((w) => w.includes("Unexpected emoticonAssetVersion format"))).toBe(true);
+    const warnings = vi
+      .mocked(console.warn)
+      .mock.calls.map((c) => c[0] as string);
+    expect(
+      warnings.some((w) =>
+        w.includes("Unexpected emoticonAssetVersion format"),
+      ),
+    ).toBe(true);
   });
 
   it("falls back to hardcoded versions when ECS is unreachable", async () => {
@@ -157,8 +187,12 @@ describe("initializeEmojiMap", () => {
     expect(resolveReactionKey("horse")).toBe("1f40e_horse");
     const calls = vi.mocked(fetch).mock.calls.map((c) => c[0] as string);
     // Should have tried ECS then a fallback CDN version
-    expect(calls.some((u) => u.includes("config.teams.microsoft.com"))).toBe(true);
-    expect(calls.some((u) => u.includes("statics.teams.cdn.office.net"))).toBe(true);
+    expect(calls.some((u) => u.includes("config.teams.microsoft.com"))).toBe(
+      true,
+    );
+    expect(calls.some((u) => u.includes("statics.teams.cdn.office.net"))).toBe(
+      true,
+    );
   });
 
   it("does not throw when all fetches fail", async () => {
@@ -236,9 +270,7 @@ describe("resolveReactionKey (map loaded)", () => {
 
   describe("unknown keys", () => {
     it("passes through unknown keys lowercased", () => {
-      expect(resolveReactionKey("unknown_emoji_xyz")).toBe(
-        "unknown_emoji_xyz",
-      );
+      expect(resolveReactionKey("unknown_emoji_xyz")).toBe("unknown_emoji_xyz");
       expect(resolveReactionKey("CustomReaction")).toBe("customreaction");
     });
   });

--- a/tests/unit/html-utils.test.ts
+++ b/tests/unit/html-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { decodeHtmlEntities } from "../../src/html-utils.js";
+import {
+  decodeHtmlEntities,
+  escapeHtml,
+  buildQuoteHtml,
+} from "../../src/html-utils.js";
 
 describe("decodeHtmlEntities", () => {
   it("decodes &nbsp; to space", () => {
@@ -54,5 +58,100 @@ describe("decodeHtmlEntities", () => {
 
   it("handles empty string", () => {
     expect(decodeHtmlEntities("")).toBe("");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes ampersands", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeHtml("<script>alert(1)</script>")).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;",
+    );
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeHtml('"hello"')).toBe("&quot;hello&quot;");
+  });
+
+  it("escapes all special characters together", () => {
+    expect(escapeHtml('a & b < c > d "e"')).toBe(
+      "a &amp; b &lt; c &gt; d &quot;e&quot;",
+    );
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+});
+
+describe("buildQuoteHtml", () => {
+  const baseOptions = {
+    messageId: "1719500000000",
+    senderMri: "8:orgid:abc-def-123",
+    senderDisplayName: "Jane Doe",
+    previewText: "Hello, this is a test message",
+  };
+
+  it("produces a blockquote with Skype schema microdata", () => {
+    const result = buildQuoteHtml(baseOptions);
+    expect(result).toContain('itemtype="http://schema.skype.com/Reply"');
+    expect(result).toContain('itemid="1719500000000"');
+    expect(result).toContain('itemprop="mri"');
+    expect(result).toContain('itemprop="preview"');
+  });
+
+  it("includes sender display name and MRI", () => {
+    const result = buildQuoteHtml(baseOptions);
+    expect(result).toContain("Jane Doe");
+    expect(result).toContain('itemid="8:orgid:abc-def-123"');
+  });
+
+  it("includes the preview text", () => {
+    const result = buildQuoteHtml(baseOptions);
+    expect(result).toContain("Hello, this is a test message");
+  });
+
+  it("truncates preview text longer than 200 characters", () => {
+    const longText = "x".repeat(250);
+    const result = buildQuoteHtml({ ...baseOptions, previewText: longText });
+    expect(result).toContain("x".repeat(197) + "...");
+    expect(result).not.toContain("x".repeat(201));
+  });
+
+  it("does not truncate preview text of exactly 200 characters", () => {
+    const exactText = "y".repeat(200);
+    const result = buildQuoteHtml({ ...baseOptions, previewText: exactText });
+    expect(result).toContain("y".repeat(200));
+    expect(result).not.toContain("...");
+  });
+
+  it("escapes HTML in sender display name", () => {
+    const result = buildQuoteHtml({
+      ...baseOptions,
+      senderDisplayName: '<script>alert("xss")</script>',
+    });
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("escapes HTML in preview text", () => {
+    const result = buildQuoteHtml({
+      ...baseOptions,
+      previewText: "a <b>bold</b> & important",
+    });
+    expect(result).toContain("a &lt;b&gt;bold&lt;/b&gt; &amp; important");
+  });
+
+  it("wraps content in blockquote tags", () => {
+    const result = buildQuoteHtml(baseOptions);
+    expect(result).toMatch(/^<blockquote\b/);
+    expect(result).toMatch(/<\/blockquote>$/);
   });
 });

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -1472,6 +1472,7 @@ describe("sendMessage", () => {
       [],
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -1497,6 +1498,7 @@ describe("sendMessage", () => {
       "Test User",
       "html",
       [],
+      undefined,
       undefined,
       undefined,
     );
@@ -1526,6 +1528,7 @@ describe("sendMessage", () => {
       [],
       undefined,
       "My Title",
+      undefined,
     );
   });
 });
@@ -2777,7 +2780,8 @@ describe("TeamsClient.fromInteractiveLogin", () => {
   const testToken = {
     skypeToken: "skype-token",
     region: "amer",
-    bearerToken: "eyJhbGciOiJSUzI1NiJ9.eyJ1cG4iOiJhbGljZUBjb250b3NvLmNvbSJ9.sig",
+    bearerToken:
+      "eyJhbGciOiJSUzI1NiJ9.eyJ1cG4iOiJhbGljZUBjb250b3NvLmNvbSJ9.sig",
     substrateToken: "substrate-token",
   };
 
@@ -2815,7 +2819,9 @@ describe("TeamsClient.fromInteractiveLogin", () => {
 
   it("should save under _default when no email available", async () => {
     const tokenWithoutBearer = { skypeToken: "sk", region: "amer" };
-    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(tokenWithoutBearer);
+    mockedAuth.acquireTokenViaInteractiveLogin.mockResolvedValue(
+      tokenWithoutBearer,
+    );
 
     await TeamsClient.fromInteractiveLogin();
 
@@ -2877,7 +2883,9 @@ describe("TeamsClient.fromDebugSession", () => {
 
   it("should save under _default when no email extractable", async () => {
     const tokenWithoutBearer = { skypeToken: "sk", region: "amer" };
-    mockedAuth.acquireTokenViaDebugSession.mockResolvedValue(tokenWithoutBearer);
+    mockedAuth.acquireTokenViaDebugSession.mockResolvedValue(
+      tokenWithoutBearer,
+    );
 
     await TeamsClient.fromDebugSession();
 

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -49,14 +49,18 @@ describe("getTelemetryDir", () => {
 
   it("returns XDG path on linux when XDG_DATA_HOME is set", () => {
     vi.stubEnv("XDG_DATA_HOME", "/custom/data");
-    expect(getTelemetryDir("linux")).toMatch(/[/\\]custom[/\\]data[/\\]teams-api$/);
+    expect(getTelemetryDir("linux")).toMatch(
+      /[/\\]custom[/\\]data[/\\]teams-api$/,
+    );
   });
 
   it("returns ~/.local/share on linux when XDG_DATA_HOME is not set", () => {
     const original = process.env.XDG_DATA_HOME;
     try {
       delete process.env.XDG_DATA_HOME;
-      expect(getTelemetryDir("linux")).toMatch(/\.local[/\\]share[/\\]teams-api$/);
+      expect(getTelemetryDir("linux")).toMatch(
+        /\.local[/\\]share[/\\]teams-api$/,
+      );
     } finally {
       if (original !== undefined) {
         process.env.XDG_DATA_HOME = original;
@@ -186,9 +190,7 @@ describe("write functions", () => {
     expect((r.error as Record<string, unknown>).message).toBe(
       "Request failed with 401",
     );
-    expect(
-      typeof (r.error as Record<string, unknown>).stack,
-    ).toBe("string");
+    expect(typeof (r.error as Record<string, unknown>).stack).toBe("string");
   });
 
   it("writes an auth record", () => {
@@ -212,9 +214,9 @@ describe("write functions", () => {
     });
     const records = readRecords();
     expect(records[0].success).toBe(false);
-    expect(
-      ((records[0].error) as Record<string, unknown>).message,
-    ).toBe("Timeout");
+    expect((records[0].error as Record<string, unknown>).message).toBe(
+      "Timeout",
+    );
   });
 
   it("appends multiple records sequentially", () => {

--- a/tests/unit/token-store.test.ts
+++ b/tests/unit/token-store.test.ts
@@ -60,10 +60,7 @@ describe("saveToken", () => {
     await saveToken(testEmail, testToken);
 
     expect(mockStore.save).toHaveBeenCalledTimes(1);
-    expect(mockStore.save).toHaveBeenCalledWith(
-      testEmail,
-      expect.any(String),
-    );
+    expect(mockStore.save).toHaveBeenCalledWith(testEmail, expect.any(String));
   });
 
   it("should store base64-encoded JSON with acquiredAt timestamp", async () => {


### PR DESCRIPTION
Ⓜ

## Summary

Adds `quoteMessageId` parameter to `send-message` and `edit-message` actions, enabling inline quotes (replies) that match the native Teams client format.

## Changes

### New utilities (`src/html-utils.ts`)
- `escapeHtml()` — escapes HTML special characters to prevent injection
- `buildQuoteHtml()` — generates Teams blockquote HTML with Skype schema microdata attributes (`http://schema.skype.com/Reply`)

### API layer (`src/api/chat-service.ts`)
- `postMessage()` and `editMessage()` accept optional `quoteHtml` parameter
- After format resolution (markdown→HTML, text, raw HTML), quote HTML is prepended
- Plain-text content is escaped when combined with a quote
- Message type is forced to `RichText/Html` when quoting

### Client layer (`src/teams-client.ts`)
- `sendMessage()` and `editMessage()` accept optional `quoteMessageId`
- Private `buildQuoteHtmlForMessage()` helper fetches the quoted message (up to 200 recent messages), extracts sender info and content preview, and builds the quote HTML

### Action layer (`src/actions/message-actions.ts`)
- `send-message` and `edit-message` actions expose `quoteMessageId` parameter
- Parameter is passed through to the client layer

### Tests
- 14 new tests for `escapeHtml` and `buildQuoteHtml` in `html-utils.test.ts`
- Updated existing `sendMessage`/`editMessage` assertions to account for new parameter

## How it works

When `quoteMessageId` is provided:
1. The client fetches recent messages from the conversation
2. Finds the target message by ID
3. Builds a blockquote HTML element with the sender's MRI, display name, and a preview of the quoted content (truncated to 200 chars)
4. The API layer prepends this blockquote to the user's message content
5. The result matches the native Teams inline reply format

Closes #31