### PR TITLE
feat: add configurable agent marker for send and edit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,23 @@ Use this only if you already have tokens from another flow or need to avoid brow
 | `TEAMS_LOGIN`            | Set to `true` to enable interactive browser login                     |
 | `TEAMS_DEBUG_PORT`       | Chrome debug port (default: 9222)                                     |
 | `TEAMS_EDIT_REPLY_GUARD` | Edit reply guard: `allow` (default), `warn`, or `block`. See below    |
+| `TEAMS_AGENT_MARKER`     | Agent marker prefix for sent/edited messages (e.g. `Ⓜ`). See below   |
+
+#### Agent marker
+
+When an AI agent sends or edits messages on behalf of a user, it can be hard to tell which messages were composed by the agent and which by the human. The `TEAMS_AGENT_MARKER` environment variable (or `--agent-marker` CLI flag / `agentMarker` MCP parameter) automatically prepends a configurable string to message content:
+
+```jsonc
+{
+  "env": {
+    "TEAMS_AGENT_MARKER": "Ⓜ", // or "🤖", "[Bot]", etc.
+  },
+}
+```
+
+When set, every `send-message` and `edit-message` call prepends the marker followed by a space to the content. For example, with `TEAMS_AGENT_MARKER=Ⓜ`, sending "Hello world" produces "Ⓜ Hello world".
+
+The per-call parameter takes precedence over the environment variable. Pass an empty string to disable the marker for a specific call.
 
 #### Edit reply guard
 

--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -372,6 +372,15 @@ export const sendMessage: ActionDefinition = {
         "is automatically fetched and included as a blockquote above your message.",
       required: false,
     },
+    {
+      name: "agentMarker",
+      type: "string",
+      description:
+        "Prefix to prepend to message content, marking it as agent-generated " +
+        '(e.g. "Ⓜ", "🤖", "[Bot]"). ' +
+        "Defaults to TEAMS_AGENT_MARKER env var. Omit or set to empty to disable.",
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     let { conversationId, label } = await resolveConversationId(
@@ -382,7 +391,13 @@ export const sendMessage: ActionDefinition = {
     if (threadMessageId) {
       conversationId = `${conversationId};messageid=${threadMessageId}`;
     }
-    const content = (parameters.content as string | undefined) ?? "";
+    const agentMarker =
+      (parameters.agentMarker as string | undefined) ??
+      process.env.TEAMS_AGENT_MARKER ??
+      "";
+    const rawContent = (parameters.content as string | undefined) ?? "";
+    const content =
+      agentMarker && rawContent ? `${agentMarker} ${rawContent}` : rawContent;
     const imagePaths = (parameters.image as string[] | undefined) ?? [];
     const filePaths = (parameters.file as string[] | undefined) ?? [];
     const scheduleAtRaw = parameters.scheduleAt as string | undefined;
@@ -558,6 +573,15 @@ export const editMessageAction: ActionDefinition = {
         'Defaults to TEAMS_EDIT_REPLY_GUARD env var, or "allow".',
       required: false,
     },
+    {
+      name: "agentMarker",
+      type: "string",
+      description:
+        "Prefix to prepend to message content, marking it as agent-generated " +
+        '(e.g. "Ⓜ", "🤖", "[Bot]"). ' +
+        "Defaults to TEAMS_AGENT_MARKER env var. Omit or set to empty to disable.",
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     const { conversationId, label } = await resolveConversationId(
@@ -565,7 +589,12 @@ export const editMessageAction: ActionDefinition = {
       parameters,
     );
     const messageId = parameters.messageId as string;
-    let content = parameters.content as string;
+    const agentMarker =
+      (parameters.agentMarker as string | undefined) ??
+      process.env.TEAMS_AGENT_MARKER ??
+      "";
+    const rawContent = parameters.content as string;
+    let content = agentMarker ? `${agentMarker} ${rawContent}` : rawContent;
     const messageFormat =
       (parameters.messageFormat as MessageFormat | undefined) ?? "markdown";
     const quoteMessageId = parameters.quoteMessageId as string | undefined;

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -1166,6 +1166,134 @@ describe("send-message", () => {
       /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/,
     ); // includes day of week
   });
+
+  describe("agent marker", () => {
+    const sentMessage: SentMessage = {
+      messageId: "1773000000000",
+      arrivalTime: 1773000000000,
+    };
+
+    it("should prepend agentMarker to content when parameter is provided", async () => {
+      const client = createMockClient({
+        sendMessage: vi.fn().mockResolvedValue(sentMessage),
+      });
+
+      await action.execute(client, {
+        conversationId: "19:chat@thread.v2",
+        content: "Hello world",
+        agentMarker: "Ⓜ",
+      });
+
+      expect(client.sendMessage).toHaveBeenCalledWith(
+        "19:chat@thread.v2",
+        "Ⓜ Hello world",
+        "markdown",
+        [],
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should not prepend marker when agentMarker is empty", async () => {
+      const client = createMockClient({
+        sendMessage: vi.fn().mockResolvedValue(sentMessage),
+      });
+
+      await action.execute(client, {
+        conversationId: "19:chat@thread.v2",
+        content: "Hello world",
+        agentMarker: "",
+      });
+
+      expect(client.sendMessage).toHaveBeenCalledWith(
+        "19:chat@thread.v2",
+        "Hello world",
+        "markdown",
+        [],
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should fall back to TEAMS_AGENT_MARKER env var", async () => {
+      const original = process.env.TEAMS_AGENT_MARKER;
+      process.env.TEAMS_AGENT_MARKER = "🤖";
+      try {
+        const client = createMockClient({
+          sendMessage: vi.fn().mockResolvedValue(sentMessage),
+        });
+
+        await action.execute(client, {
+          conversationId: "19:chat@thread.v2",
+          content: "Hello world",
+        });
+
+        expect(client.sendMessage).toHaveBeenCalledWith(
+          "19:chat@thread.v2",
+          "🤖 Hello world",
+          "markdown",
+          [],
+          undefined,
+          undefined,
+        );
+      } finally {
+        if (original === undefined) {
+          delete process.env.TEAMS_AGENT_MARKER;
+        } else {
+          process.env.TEAMS_AGENT_MARKER = original;
+        }
+      }
+    });
+
+    it("should prefer parameter over env var", async () => {
+      const original = process.env.TEAMS_AGENT_MARKER;
+      process.env.TEAMS_AGENT_MARKER = "🤖";
+      try {
+        const client = createMockClient({
+          sendMessage: vi.fn().mockResolvedValue(sentMessage),
+        });
+
+        await action.execute(client, {
+          conversationId: "19:chat@thread.v2",
+          content: "Hello world",
+          agentMarker: "[Bot]",
+        });
+
+        expect(client.sendMessage).toHaveBeenCalledWith(
+          "19:chat@thread.v2",
+          "[Bot] Hello world",
+          "markdown",
+          [],
+          undefined,
+          undefined,
+        );
+      } finally {
+        if (original === undefined) {
+          delete process.env.TEAMS_AGENT_MARKER;
+        } else {
+          process.env.TEAMS_AGENT_MARKER = original;
+        }
+      }
+    });
+
+    it("should not prepend marker when content is empty", async () => {
+      const client = createMockClient({
+        sendMessage: vi.fn().mockResolvedValue(sentMessage),
+      });
+
+      // Empty content stays empty — marker is not prepended to nothing.
+      // This also means the "at least one of" validation still triggers.
+      await expect(
+        action.execute(client, {
+          conversationId: "19:chat@thread.v2",
+          content: "",
+          agentMarker: "Ⓜ",
+        }),
+      ).rejects.toThrow(
+        "At least one of --content, --image, or --file must be provided",
+      );
+    });
+  });
 });
 
 // ── edit-message ─────────────────────────────────────────────────────
@@ -1510,6 +1638,110 @@ describe("edit-message", () => {
           process.env.TEAMS_EDIT_REPLY_GUARD = original;
         }
       }
+    });
+  });
+
+  describe("agent marker", () => {
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-03-24T10:00:00.000Z",
+    };
+
+    it("should prepend agentMarker to content when parameter is provided", async () => {
+      const client = createMockClient({
+        editMessage: vi.fn().mockResolvedValue(editedMessage),
+      });
+
+      await action.execute(client, {
+        conversationId: "19:chat@thread.v2",
+        messageId: "msg-123",
+        content: "Updated content",
+        agentMarker: "Ⓜ",
+      });
+
+      expect(client.editMessage).toHaveBeenCalledWith(
+        "19:chat@thread.v2",
+        "msg-123",
+        "Ⓜ Updated content",
+        "markdown",
+        undefined,
+      );
+    });
+
+    it("should not prepend marker when agentMarker is empty", async () => {
+      const client = createMockClient({
+        editMessage: vi.fn().mockResolvedValue(editedMessage),
+      });
+
+      await action.execute(client, {
+        conversationId: "19:chat@thread.v2",
+        messageId: "msg-123",
+        content: "Updated content",
+        agentMarker: "",
+      });
+
+      expect(client.editMessage).toHaveBeenCalledWith(
+        "19:chat@thread.v2",
+        "msg-123",
+        "Updated content",
+        "markdown",
+        undefined,
+      );
+    });
+
+    it("should fall back to TEAMS_AGENT_MARKER env var", async () => {
+      const original = process.env.TEAMS_AGENT_MARKER;
+      process.env.TEAMS_AGENT_MARKER = "[Agent]";
+      try {
+        const client = createMockClient({
+          editMessage: vi.fn().mockResolvedValue(editedMessage),
+        });
+
+        await action.execute(client, {
+          conversationId: "19:chat@thread.v2",
+          messageId: "msg-123",
+          content: "Updated content",
+        });
+
+        expect(client.editMessage).toHaveBeenCalledWith(
+          "19:chat@thread.v2",
+          "msg-123",
+          "[Agent] Updated content",
+          "markdown",
+          undefined,
+        );
+      } finally {
+        if (original === undefined) {
+          delete process.env.TEAMS_AGENT_MARKER;
+        } else {
+          process.env.TEAMS_AGENT_MARKER = original;
+        }
+      }
+    });
+
+    it("should apply marker before reply guard annotation", async () => {
+      const client = createMockClient({
+        checkForReplies: vi
+          .fn()
+          .mockResolvedValue({ hasReplies: true, replyCount: 2 }),
+        editMessage: vi.fn().mockResolvedValue(editedMessage),
+      });
+
+      await action.execute(client, {
+        conversationId: "19:chat@thread.v2",
+        messageId: "msg-123",
+        content: "Updated content",
+        agentMarker: "Ⓜ",
+        replyGuard: "warn",
+      });
+
+      expect(client.editMessage).toHaveBeenCalledWith(
+        "19:chat@thread.v2",
+        "msg-123",
+        "Ⓜ Updated content\n\n⚠️ _This message was edited after receiving 2 replies._",
+        "markdown",
+        undefined,
+      );
     });
   });
 });


### PR DESCRIPTION
Ⓜ

## Summary

Adds a configurable `agentMarker` parameter to both `sendMessage` and `editMessage` actions that prepends a prefix to message content. This formalizes the manual Ⓜ prefix pattern into the library itself, enabling AI agents to transparently mark their messages.

## Changes

- Added `agentMarker` parameter to `sendMessage` and `editMessage` actions
- Added `TEAMS_AGENT_MARKER` environment variable as a default fallback
- Updated README with documentation for the new feature
- Added comprehensive tests (9 new tests covering both actions)

## Behavior

- Per-call parameter takes precedence over env var
- Empty string (`""`) explicitly disables the marker (overrides env var)
- Marker is not prepended to empty content (prevents trailing whitespace on image-only messages)
- For `editMessage`, marker is applied before reply guard annotation

## Example

```bash
# Via env var (applied to all messages)
export TEAMS_AGENT_MARKER="Ⓜ"

# Via parameter (per-call override)
teams-api-mcp send-message --content "Hello" --agentMarker "🤖"
```

Closes #25
Closes #29