### PR TITLE
feat: add configurable soft-delete mode for message deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ Use this only if you already have tokens from another flow or need to avoid brow
 | `TEAMS_DEBUG_PORT`       | Chrome debug port (default: 9222)                                     |
 | `TEAMS_EDIT_REPLY_GUARD` | Edit reply guard: `allow` (default), `warn`, or `block`. See below    |
 | `TEAMS_AGENT_MARKER`     | Agent marker prefix for sent/edited messages (e.g. `Ⓜ`). See below   |
+| `TEAMS_DELETE_MODE`      | Delete mode: `hard` (default), `soft`, or `block`. See below          |
+| `TEAMS_DELETE_TOMBSTONE` | Custom tombstone text for soft-delete mode. See below                 |
 
 #### Agent marker
 
@@ -421,6 +423,29 @@ When editing a message that already has replies, the original context can be los
 | `block` | Edit is refused with an error listing the reply count                              |
 
 The per-call parameter takes precedence over the environment variable.
+
+#### Delete mode (soft-delete)
+
+Hard-deleting messages removes content permanently, which can be problematic for auditability and conversation flow in group chats. The `TEAMS_DELETE_MODE` environment variable (or `--delete-mode` CLI flag / `deleteMode` MCP parameter) controls how message deletion is handled:
+
+| Value   | Behavior                                                            |
+| ------- | ------------------------------------------------------------------- |
+| `hard`  | Permanently delete the message (default, current behavior)          |
+| `soft`  | Replace message content with a tombstone marker instead of deleting |
+| `block` | Refuse deletion entirely with an error                              |
+
+When using `soft` mode, the message content is replaced with `~~This message was removed by an agent~~` by default. Customize the tombstone text with `TEAMS_DELETE_TOMBSTONE` (or `--delete-tombstone` / `deleteTombstone`):
+
+```jsonc
+{
+  "env": {
+    "TEAMS_DELETE_MODE": "soft",
+    "TEAMS_DELETE_TOMBSTONE": "🗑️ [removed by automation]",
+  },
+}
+```
+
+The per-call parameters take precedence over environment variables.
 
 ### Available tools
 

--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -13,6 +13,7 @@ import type {
   FileSharingScope,
   ScheduledMessage,
   ReplyGuard,
+  DeleteMode,
 } from "../types.js";
 import { isTextMessageType } from "../constants.js";
 import {
@@ -648,6 +649,8 @@ export const editMessageAction: ActionDefinition = {
   },
 };
 
+const DEFAULT_DELETE_TOMBSTONE = "~~This message was removed by an agent~~";
+
 export const deleteMessageAction: ActionDefinition = {
   name: "delete-message",
   title: "Delete Message",
@@ -665,6 +668,24 @@ export const deleteMessageAction: ActionDefinition = {
       description: "ID of the message to delete",
       required: true,
     },
+    {
+      name: "deleteMode",
+      type: "string",
+      description:
+        'Controls how deletion is handled: "hard" (permanently delete, default), ' +
+        '"soft" (replace content with tombstone marker), "block" (refuse deletion). ' +
+        'Defaults to TEAMS_DELETE_MODE env var, or "hard".',
+      required: false,
+    },
+    {
+      name: "deleteTombstone",
+      type: "string",
+      description:
+        'Custom tombstone text used when deleteMode is "soft". ' +
+        "Defaults to TEAMS_DELETE_TOMBSTONE env var, or " +
+        `"${DEFAULT_DELETE_TOMBSTONE}".`,
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     const { conversationId, label } = await resolveConversationId(
@@ -672,14 +693,59 @@ export const deleteMessageAction: ActionDefinition = {
       parameters,
     );
     const messageId = parameters.messageId as string;
+
+    const deleteMode: DeleteMode =
+      (parameters.deleteMode as DeleteMode | undefined) ??
+      (process.env.TEAMS_DELETE_MODE as DeleteMode | undefined) ??
+      "hard";
+
+    if (deleteMode === "block") {
+      throw new Error(
+        `Cannot delete message ${messageId}: delete mode is set to "block". ` +
+          `Pass --delete-mode hard to override.`,
+      );
+    }
+
+    if (deleteMode === "soft") {
+      const tombstone =
+        (parameters.deleteTombstone as string | undefined) ??
+        process.env.TEAMS_DELETE_TOMBSTONE ??
+        DEFAULT_DELETE_TOMBSTONE;
+
+      const result = await client.editMessage(
+        conversationId,
+        messageId,
+        tombstone,
+        "markdown",
+      );
+      return {
+        messageId: result.messageId,
+        editTime: result.editTime,
+        conversation: label,
+        softDeleted: true,
+      };
+    }
+
     const result = await client.deleteMessage(conversationId, messageId);
     return { ...result, conversation: label };
   },
   formatConcise: (result) => {
-    const { messageId, conversation } = result as {
+    const { messageId, conversation, softDeleted, editTime } = result as {
       messageId: string;
       conversation: string;
+      softDeleted?: boolean;
+      editTime?: string;
     };
+    if (softDeleted) {
+      return [
+        "## Message Soft-Deleted",
+        "",
+        `- **In:** ${conversation}`,
+        `- **Message ID:** ${messageId}`,
+        `- **Edit time:** ${editTime}`,
+        "- **Mode:** Content replaced with tombstone marker",
+      ].join("\n");
+    }
     return [
       "## Message Deleted",
       "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,15 @@ export type MessageFormat = "text" | "markdown" | "html";
  */
 export type ReplyGuard = "allow" | "warn" | "block";
 
+/**
+ * Controls how message deletion is handled.
+ *
+ * - `"hard"` — permanently delete the message (default, current behavior).
+ * - `"soft"` — replace message content with a tombstone marker instead of deleting.
+ * - `"block"` — refuse deletion entirely with an error.
+ */
+export type DeleteMode = "hard" | "soft" | "block";
+
 /** Result of checking whether a message has thread replies. */
 export interface ReplyCheckResult {
   /** Whether the message has at least one reply. */

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -27,6 +27,7 @@ import type {
   DeletedMessage,
   ReactionResult,
   ScheduledMessage,
+  DeleteMode,
 } from "../../src/types.js";
 
 // ── Mock client factory ──────────────────────────────────────────────
@@ -1751,7 +1752,7 @@ describe("edit-message", () => {
 describe("delete-message", () => {
   const action = getAction("delete-message");
 
-  it("should resolve conversation and delete message", async () => {
+  it("should resolve conversation and delete message (hard mode by default)", async () => {
     const conversation = makeConversation({
       id: "19:chat@thread.v2",
       topic: "Design Review",
@@ -1802,7 +1803,7 @@ describe("delete-message", () => {
     ).rejects.toThrow("One of --conversation-id, --chat, or --to is required.");
   });
 
-  it("should format result correctly", () => {
+  it("should format hard-delete result correctly", () => {
     const result = {
       messageId: "msg-123",
       conversation: "Design Review",
@@ -1813,6 +1814,210 @@ describe("delete-message", () => {
     expect(output).toContain("## Message Deleted");
     expect(output).toContain("**From:** Design Review");
     expect(output).toContain("**Message ID:** msg-123");
+  });
+
+  // ── soft-delete mode ──
+
+  it("should replace content with default tombstone when deleteMode is 'soft'", async () => {
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    const result = (await action.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+      deleteMode: "soft",
+    })) as { messageId: string; softDeleted: boolean; editTime: string };
+
+    expect(client.editMessage).toHaveBeenCalledWith(
+      "19:chat@thread.v2",
+      "msg-123",
+      "~~This message was removed by an agent~~",
+      "markdown",
+    );
+    expect(client.deleteMessage).not.toHaveBeenCalled();
+    expect(result.softDeleted).toBe(true);
+    expect(result.editTime).toBe("2026-04-12T09:00:00Z");
+  });
+
+  it("should use custom tombstone from parameter", async () => {
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    const result = (await action.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+      deleteMode: "soft",
+      deleteTombstone: "[REDACTED]",
+    })) as { messageId: string; softDeleted: boolean };
+
+    expect(client.editMessage).toHaveBeenCalledWith(
+      "19:chat@thread.v2",
+      "msg-123",
+      "[REDACTED]",
+      "markdown",
+    );
+    expect(result.softDeleted).toBe(true);
+  });
+
+  it("should fall back to TEAMS_DELETE_MODE env var", async () => {
+    process.env.TEAMS_DELETE_MODE = "soft";
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await action.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+    });
+
+    expect(client.editMessage).toHaveBeenCalled();
+    expect(client.deleteMessage).not.toHaveBeenCalled();
+    delete process.env.TEAMS_DELETE_MODE;
+  });
+
+  it("should fall back to TEAMS_DELETE_TOMBSTONE env var for tombstone text", async () => {
+    process.env.TEAMS_DELETE_MODE = "soft";
+    process.env.TEAMS_DELETE_TOMBSTONE = "🗑️ removed";
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await action.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+    });
+
+    expect(client.editMessage).toHaveBeenCalledWith(
+      "19:chat@thread.v2",
+      "msg-123",
+      "🗑️ removed",
+      "markdown",
+    );
+    delete process.env.TEAMS_DELETE_MODE;
+    delete process.env.TEAMS_DELETE_TOMBSTONE;
+  });
+
+  it("should prefer parameter over env var for deleteMode", async () => {
+    process.env.TEAMS_DELETE_MODE = "soft";
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const deletedMessage: DeletedMessage = { messageId: "msg-123" };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      deleteMessage: vi.fn().mockResolvedValue(deletedMessage),
+    });
+
+    await action.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+      deleteMode: "hard",
+    });
+
+    expect(client.deleteMessage).toHaveBeenCalled();
+    expect(client.editMessage).not.toHaveBeenCalled();
+    delete process.env.TEAMS_DELETE_MODE;
+  });
+
+  // ── block mode ──
+
+  it("should refuse deletion when deleteMode is 'block'", async () => {
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    await expect(
+      action.execute(client, {
+        chat: "Design Review",
+        messageId: "msg-123",
+        deleteMode: "block",
+      }),
+    ).rejects.toThrow(
+      'Cannot delete message msg-123: delete mode is set to "block"',
+    );
+    expect(client.deleteMessage).not.toHaveBeenCalled();
+    expect(client.editMessage).not.toHaveBeenCalled();
+  });
+
+  it("should refuse deletion when TEAMS_DELETE_MODE is 'block'", async () => {
+    process.env.TEAMS_DELETE_MODE = "block";
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    await expect(
+      action.execute(client, {
+        chat: "Design Review",
+        messageId: "msg-123",
+      }),
+    ).rejects.toThrow('delete mode is set to "block"');
+    delete process.env.TEAMS_DELETE_MODE;
+  });
+
+  // ── soft-delete formatting ──
+
+  it("should format soft-delete result correctly", () => {
+    const result = {
+      messageId: "msg-123",
+      conversation: "Design Review",
+      softDeleted: true,
+      editTime: "2026-04-12T09:00:00Z",
+    };
+
+    const output = action.formatConcise(result);
+
+    expect(output).toContain("## Message Soft-Deleted");
+    expect(output).toContain("**In:** Design Review");
+    expect(output).toContain("**Message ID:** msg-123");
+    expect(output).toContain("**Edit time:** 2026-04-12T09:00:00Z");
+    expect(output).toContain("tombstone marker");
   });
 });
 


### PR DESCRIPTION
Ⓜ

## Summary

Adds a configurable delete mode that lets users choose between permanently deleting messages, replacing them with a tombstone marker (soft-delete), or blocking deletion entirely.

## Changes

### New `deleteMode` parameter (`hard` | `soft` | `block`)

| Mode | Behavior |
| --- | --- |
| `hard` | Permanently delete the message (default, backward-compatible) |
| `soft` | Replace message content with a tombstone marker via edit |
| `block` | Refuse deletion entirely with an error |

### New `deleteTombstone` parameter

Custom tombstone text for soft-delete mode. Defaults to `~~This message was removed by an agent~~`.

### Environment variables

- `TEAMS_DELETE_MODE` — set default mode globally
- `TEAMS_DELETE_TOMBSTONE` — set default tombstone text globally

Per-call parameters take precedence over environment variables.

### Pattern

Follows the same precedence pattern as `replyGuard` and `agentMarker`: parameter → env var → default.

## Testing

- 8 new test cases covering: soft-delete with default/custom tombstone, block mode, env var fallbacks, parameter precedence, and format output.
- All existing delete tests adapted and passing.

Closes #27