### PR TITLE
feat: add configurable audit logging for edit and delete actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Use this only if you already have tokens from another flow or need to avoid brow
 | `TEAMS_AGENT_MARKER`     | Agent marker prefix for sent/edited messages (e.g. `Ⓜ`). See below   |
 | `TEAMS_DELETE_MODE`      | Delete mode: `hard` (default), `soft`, or `block`. See below          |
 | `TEAMS_DELETE_TOMBSTONE` | Custom tombstone text for soft-delete mode. See below                 |
+| `TEAMS_AUDIT_LOG`        | Audit logging: `off` (default), `stderr`, or `file:<path>`. See below |
 
 #### Agent marker
 
@@ -446,6 +447,37 @@ When using `soft` mode, the message content is replaced with `~~This message was
 ```
 
 The per-call parameters take precedence over environment variables.
+
+#### Audit logging
+
+State-modifying actions (edit and delete) can emit structured audit events for compliance and traceability. The `TEAMS_AUDIT_LOG` environment variable controls where events are written:
+
+| Value         | Behavior                                                    |
+| ------------- | ----------------------------------------------------------- |
+| `off`         | No audit logging (default)                                  |
+| `stderr`      | Write JSON Lines to stderr                                  |
+| `file:<path>` | Append JSON Lines to the specified file (created on demand) |
+
+```jsonc
+{
+  "env": {
+    "TEAMS_AUDIT_LOG": "file:/var/log/teams-audit.jsonl",
+  },
+}
+```
+
+Each event is a single JSON line with the following fields:
+
+| Field               | Description                                                                   |
+| ------------------- | ----------------------------------------------------------------------------- |
+| `timestamp`         | ISO 8601 timestamp                                                            |
+| `action`            | `"edit"`, `"delete"`, or `"soft-delete"`                                      |
+| `conversationId`    | Conversation thread ID                                                        |
+| `conversationLabel` | Human-readable conversation label (topic or 1:1 partner name)                 |
+| `messageId`         | Target message ID                                                             |
+| `content`           | New content for edits, tombstone text for soft-delete, `null` for hard delete |
+
+Audit logging is designed to be silent — errors in the audit pipeline never affect tool execution.
 
 ### Available tools
 

--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -25,6 +25,7 @@ import {
   conversationParameters,
   resolveConversationId,
 } from "./conversation-resolution.js";
+import { emitAuditEvent } from "../audit.js";
 
 /** Map file extension to MIME content type. */
 function contentTypeFromExtension(filePath: string): string {
@@ -631,6 +632,16 @@ export const editMessageAction: ActionDefinition = {
       messageFormat,
       quoteMessageId,
     );
+
+    emitAuditEvent({
+      timestamp: new Date().toISOString(),
+      action: "edit",
+      conversationId,
+      conversationLabel: label,
+      messageId,
+      content,
+    });
+
     return { ...result, conversation: label };
   },
   formatConcise: (result) => {
@@ -718,6 +729,16 @@ export const deleteMessageAction: ActionDefinition = {
         tombstone,
         "markdown",
       );
+
+      emitAuditEvent({
+        timestamp: new Date().toISOString(),
+        action: "soft-delete",
+        conversationId,
+        conversationLabel: label,
+        messageId,
+        content: tombstone,
+      });
+
       return {
         messageId: result.messageId,
         editTime: result.editTime,
@@ -727,6 +748,16 @@ export const deleteMessageAction: ActionDefinition = {
     }
 
     const result = await client.deleteMessage(conversationId, messageId);
+
+    emitAuditEvent({
+      timestamp: new Date().toISOString(),
+      action: "delete",
+      conversationId,
+      conversationLabel: label,
+      messageId,
+      content: null,
+    });
+
     return { ...result, conversation: label };
   },
   formatConcise: (result) => {

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,0 +1,50 @@
+/**
+ * Audit logging for state-modifying Teams actions.
+ *
+ * Emits structured JSON Lines to stderr or a file for compliance and audit trails.
+ * Controlled by the TEAMS_AUDIT_LOG environment variable:
+ *   - "off" or unset — no audit logging (default)
+ *   - "stderr" — write to stderr
+ *   - "file:/path/to/audit.jsonl" — append to file
+ *
+ * Audit failures are silent — they must never break the tool.
+ */
+
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type { AuditDestination, AuditEvent } from "./types.js";
+
+/** Resolve the audit destination from the TEAMS_AUDIT_LOG environment variable. */
+export function resolveAuditDestination(): AuditDestination {
+  const value = process.env.TEAMS_AUDIT_LOG?.trim();
+  if (!value || value === "off") return "off";
+  if (value === "stderr") return "stderr";
+  if (value.startsWith("file:")) return value as AuditDestination;
+  return "off";
+}
+
+/** Emit a structured audit event to the configured destination. */
+export function emitAuditEvent(event: AuditEvent): void {
+  const destination = resolveAuditDestination();
+  if (destination === "off") return;
+
+  try {
+    const line = JSON.stringify(event) + "\n";
+
+    if (destination === "stderr") {
+      process.stderr.write(line);
+      return;
+    }
+
+    if (destination.startsWith("file:")) {
+      const filePath = destination.slice("file:".length);
+      const directory = dirname(filePath);
+      if (!existsSync(directory)) {
+        mkdirSync(directory, { recursive: true });
+      }
+      appendFileSync(filePath, line, "utf-8");
+    }
+  } catch {
+    // Audit failures must never surface to the user
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -439,6 +439,31 @@ export interface ChatSearchResult {
   totalMemberCount: number;
 }
 
+/**
+ * Configures audit logging for state-modifying actions (edit, delete).
+ *
+ * - `"off"` — no audit logging (default).
+ * - `"stderr"` — write JSON Lines to stderr.
+ * - `"file:<path>"` — append JSON Lines to the specified file path.
+ */
+export type AuditDestination = "off" | "stderr" | `file:${string}`;
+
+/** A structured audit event emitted for edit and delete actions. */
+export interface AuditEvent {
+  /** ISO 8601 timestamp when the event was emitted. */
+  timestamp: string;
+  /** The action that was performed. */
+  action: "edit" | "delete" | "soft-delete";
+  /** Conversation thread ID. */
+  conversationId: string;
+  /** Human-readable conversation label (topic name or 1:1 partner). */
+  conversationLabel: string;
+  /** The target message ID. */
+  messageId: string;
+  /** Content set on the message (new content for edits, tombstone for soft-delete, null for hard delete). */
+  content: string | null;
+}
+
 /** Thread types that represent system streams, not user conversations. */
 export const SYSTEM_STREAM_TYPES = [
   "streamofannotations",

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit tests for audit logging (src/audit.ts).
+ *
+ * Tests the audit event emission to stderr and file destinations,
+ * and integration with edit/delete actions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveAuditDestination, emitAuditEvent } from "../../src/audit.js";
+import { actions } from "../../src/actions/definitions.js";
+import type { TeamsClient } from "../../src/teams-client.js";
+import type {
+  Conversation,
+  EditedMessage,
+  DeletedMessage,
+  AuditEvent,
+} from "../../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getAction(name: string) {
+  const action = actions.find((a) => a.name === name);
+  if (!action) throw new Error(`Action "${name}" not found`);
+  return action;
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "19:test@thread.space",
+    topic: "Test Chat",
+    threadType: "chat",
+    version: 1,
+    lastMessageTime: "2026-03-16T10:00:00.000Z",
+    memberCount: 5,
+    ...overrides,
+  };
+}
+
+function createMockClient(
+  overrides: Partial<Record<keyof TeamsClient, unknown>> = {},
+): TeamsClient {
+  return {
+    listConversations: vi.fn(),
+    findConversation: vi.fn(),
+    findOneOnOneConversation: vi.fn(),
+    findPeople: vi.fn(),
+    findChats: vi.fn(),
+    getMessages: vi.fn(),
+    getMessagesPage: vi.fn(),
+    sendMessage: vi.fn(),
+    sendMessageWithImages: vi.fn(),
+    sendMessageWithFiles: vi.fn(),
+    editMessage: vi.fn(),
+    checkForReplies: vi
+      .fn()
+      .mockResolvedValue({ hasReplies: false, replyCount: 0 }),
+    deleteMessage: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    scheduleMessage: vi.fn(),
+    getMembers: vi.fn(),
+    getCurrentUserDisplayName: vi.fn(),
+    getToken: vi.fn(() => ({ skypeToken: "test-token", region: "apac" })),
+    setEmail: vi.fn(),
+    ...overrides,
+  } as unknown as TeamsClient;
+}
+
+// ── resolveAuditDestination ──────────────────────────────────────────
+
+describe("resolveAuditDestination", () => {
+  beforeEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+  });
+
+  it("should return 'off' when TEAMS_AUDIT_LOG is not set", () => {
+    expect(resolveAuditDestination()).toBe("off");
+  });
+
+  it("should return 'off' when TEAMS_AUDIT_LOG is empty", () => {
+    process.env.TEAMS_AUDIT_LOG = "";
+    expect(resolveAuditDestination()).toBe("off");
+  });
+
+  it("should return 'off' when TEAMS_AUDIT_LOG is 'off'", () => {
+    process.env.TEAMS_AUDIT_LOG = "off";
+    expect(resolveAuditDestination()).toBe("off");
+  });
+
+  it("should return 'stderr' when TEAMS_AUDIT_LOG is 'stderr'", () => {
+    process.env.TEAMS_AUDIT_LOG = "stderr";
+    expect(resolveAuditDestination()).toBe("stderr");
+  });
+
+  it("should return file destination when TEAMS_AUDIT_LOG starts with 'file:'", () => {
+    process.env.TEAMS_AUDIT_LOG = "file:/tmp/audit.jsonl";
+    expect(resolveAuditDestination()).toBe("file:/tmp/audit.jsonl");
+  });
+
+  it("should trim whitespace from TEAMS_AUDIT_LOG", () => {
+    process.env.TEAMS_AUDIT_LOG = "  stderr  ";
+    expect(resolveAuditDestination()).toBe("stderr");
+  });
+
+  it("should return 'off' for unrecognized values", () => {
+    process.env.TEAMS_AUDIT_LOG = "webhook:https://example.com";
+    expect(resolveAuditDestination()).toBe("off");
+  });
+});
+
+// ── emitAuditEvent ───────────────────────────────────────────────────
+
+describe("emitAuditEvent", () => {
+  let temporaryDirectory: string;
+
+  const sampleEvent: AuditEvent = {
+    timestamp: "2026-04-12T09:00:00.000Z",
+    action: "edit",
+    conversationId: "19:chat@thread.v2",
+    conversationLabel: "Design Review",
+    messageId: "msg-123",
+    content: "Updated content",
+  };
+
+  beforeEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "audit-test-"));
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    if (existsSync(temporaryDirectory)) {
+      rmSync(temporaryDirectory, { recursive: true });
+    }
+  });
+
+  it("should not write anything when audit is off", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    emitAuditEvent(sampleEvent);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
+  it("should write JSON line to stderr when destination is stderr", () => {
+    process.env.TEAMS_AUDIT_LOG = "stderr";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    emitAuditEvent(sampleEvent);
+
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    const written = stderrSpy.mock.calls[0][0] as string;
+    expect(written).toMatch(/\n$/);
+    const parsed = JSON.parse(written.trimEnd());
+    expect(parsed.action).toBe("edit");
+    expect(parsed.conversationId).toBe("19:chat@thread.v2");
+    expect(parsed.messageId).toBe("msg-123");
+    expect(parsed.content).toBe("Updated content");
+
+    stderrSpy.mockRestore();
+  });
+
+  it("should append JSON line to file when destination is file:<path>", () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    emitAuditEvent(sampleEvent);
+
+    const contents = readFileSync(filePath, "utf-8");
+    const lines = contents.trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.action).toBe("edit");
+    expect(parsed.messageId).toBe("msg-123");
+  });
+
+  it("should append multiple events to the same file", () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    emitAuditEvent(sampleEvent);
+    emitAuditEvent({ ...sampleEvent, action: "delete", content: null });
+
+    const contents = readFileSync(filePath, "utf-8");
+    const lines = contents.trimEnd().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).action).toBe("edit");
+    expect(JSON.parse(lines[1]).action).toBe("delete");
+  });
+
+  it("should create parent directories for file destination", () => {
+    const filePath = join(temporaryDirectory, "nested", "deep", "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    emitAuditEvent(sampleEvent);
+
+    expect(existsSync(filePath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8").trimEnd());
+    expect(parsed.action).toBe("edit");
+  });
+
+  it("should silently handle write errors", () => {
+    process.env.TEAMS_AUDIT_LOG = "file:/nonexistent-root-path/audit.jsonl";
+
+    // Should not throw
+    expect(() => emitAuditEvent(sampleEvent)).not.toThrow();
+  });
+});
+
+// ── Integration: edit-message audit ──────────────────────────────────
+
+describe("edit-message audit logging", () => {
+  const editAction = getAction("edit-message");
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "audit-edit-test-"));
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_AGENT_MARKER;
+    if (existsSync(temporaryDirectory)) {
+      rmSync(temporaryDirectory, { recursive: true });
+    }
+  });
+
+  it("should emit audit event after successful edit", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await editAction.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+      content: "Updated content",
+    });
+
+    const contents = readFileSync(filePath, "utf-8");
+    const event = JSON.parse(contents.trimEnd()) as AuditEvent;
+    expect(event.action).toBe("edit");
+    expect(event.conversationId).toBe("19:chat@thread.v2");
+    expect(event.conversationLabel).toBe("Design Review");
+    expect(event.messageId).toBe("msg-123");
+    expect(event.content).toBe("Updated content");
+    expect(event.timestamp).toBeTruthy();
+  });
+
+  it("should include agent marker in audited content", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+    process.env.TEAMS_AGENT_MARKER = "Ⓜ";
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Test Chat",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-456",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await editAction.execute(client, {
+      chat: "Test Chat",
+      messageId: "msg-456",
+      content: "Hello",
+    });
+
+    const event = JSON.parse(
+      readFileSync(filePath, "utf-8").trimEnd(),
+    ) as AuditEvent;
+    expect(event.content).toBe("Ⓜ Hello");
+  });
+
+  it("should not emit audit event when audit is off", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    // TEAMS_AUDIT_LOG not set — defaults to off
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Test Chat",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-789",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await editAction.execute(client, {
+      chat: "Test Chat",
+      messageId: "msg-789",
+      content: "No audit",
+    });
+
+    expect(existsSync(filePath)).toBe(false);
+  });
+});
+
+// ── Integration: delete-message audit ────────────────────────────────
+
+describe("delete-message audit logging", () => {
+  const deleteAction = getAction("delete-message");
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_DELETE_MODE;
+    delete process.env.TEAMS_DELETE_TOMBSTONE;
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "audit-delete-test-"));
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_DELETE_MODE;
+    delete process.env.TEAMS_DELETE_TOMBSTONE;
+    if (existsSync(temporaryDirectory)) {
+      rmSync(temporaryDirectory, { recursive: true });
+    }
+  });
+
+  it("should emit audit event for hard delete", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const deletedMessage: DeletedMessage = { messageId: "msg-123" };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      deleteMessage: vi.fn().mockResolvedValue(deletedMessage),
+    });
+
+    await deleteAction.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+    });
+
+    const contents = readFileSync(filePath, "utf-8");
+    const event = JSON.parse(contents.trimEnd()) as AuditEvent;
+    expect(event.action).toBe("delete");
+    expect(event.conversationId).toBe("19:chat@thread.v2");
+    expect(event.conversationLabel).toBe("Design Review");
+    expect(event.messageId).toBe("msg-123");
+    expect(event.content).toBeNull();
+  });
+
+  it("should emit audit event for soft delete with default tombstone", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Design Review",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-123",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await deleteAction.execute(client, {
+      chat: "Design Review",
+      messageId: "msg-123",
+      deleteMode: "soft",
+    });
+
+    const event = JSON.parse(
+      readFileSync(filePath, "utf-8").trimEnd(),
+    ) as AuditEvent;
+    expect(event.action).toBe("soft-delete");
+    expect(event.content).toBe("~~This message was removed by an agent~~");
+  });
+
+  it("should emit audit event for soft delete with custom tombstone", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Test Chat",
+    });
+    const editedMessage: EditedMessage = {
+      messageId: "msg-456",
+      editTime: "2026-04-12T09:00:00Z",
+    };
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn().mockResolvedValue(editedMessage),
+    });
+
+    await deleteAction.execute(client, {
+      chat: "Test Chat",
+      messageId: "msg-456",
+      deleteMode: "soft",
+      deleteTombstone: "🗑️ [removed]",
+    });
+
+    const event = JSON.parse(
+      readFileSync(filePath, "utf-8").trimEnd(),
+    ) as AuditEvent;
+    expect(event.action).toBe("soft-delete");
+    expect(event.content).toBe("🗑️ [removed]");
+  });
+
+  it("should not emit audit event when delete is blocked", async () => {
+    const filePath = join(temporaryDirectory, "audit.jsonl");
+    process.env.TEAMS_AUDIT_LOG = `file:${filePath}`;
+
+    const conversation = makeConversation({
+      id: "19:chat@thread.v2",
+      topic: "Test Chat",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    await expect(
+      deleteAction.execute(client, {
+        chat: "Test Chat",
+        messageId: "msg-789",
+        deleteMode: "block",
+      }),
+    ).rejects.toThrow('delete mode is set to "block"');
+
+    expect(existsSync(filePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
Ⓜ

## Summary

Adds structured JSON Lines audit logging for state-modifying Teams actions (edit, delete, soft-delete), controlled by the `TEAMS_AUDIT_LOG` environment variable.

## Changes

- **`src/audit.ts`** — New module with `resolveAuditDestination()` and `emitAuditEvent()` functions
- **`src/types.ts`** — Added `AuditDestination` type and `AuditEvent` interface
- **`src/actions/message-actions.ts`** — Hooked audit emission into edit-message and delete-message (both hard and soft paths)
- **`tests/unit/audit.test.ts`** — 20 tests covering unit and integration scenarios
- **`README.md`** — Documentation for the `TEAMS_AUDIT_LOG` env var and event schema

## Configuration

| Value | Behavior |
|-------|---------|
| `off` (default) | No audit logging |
| `stderr` | Write JSON Lines to stderr |
| `file:<path>` | Append JSON Lines to file (auto-creates directories) |

## Design decisions

- **No per-call override** — audit is a global policy (agents should not opt out)
- **Post-execution emission** — events emitted after successful action, consistent with telemetry pattern
- **Silent failures** — audit errors never surface to the user or break tool execution
- **Scope: edit and delete only** — send actions excluded per issue requirements

Closes #28