### PR TITLE
feat: add protected conversations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,21 +381,22 @@ Use this only if you already have tokens from another flow or need to avoid brow
 
 ### Environment variables
 
-| Variable                 | Description                                                           |
-| ------------------------ | --------------------------------------------------------------------- |
-| `TEAMS_TOKEN`            | Pre-existing skype token                                              |
-| `TEAMS_BEARER_TOKEN`     | Optional middle-tier bearer token                                     |
-| `TEAMS_SUBSTRATE_TOKEN`  | Optional Substrate bearer token                                       |
-| `TEAMS_REGION`           | API region override. Required with `TEAMS_TOKEN`; optional otherwise  |
-| `TEAMS_EMAIL`            | Corporate email. Optional — the server prompts the AI agent if needed |
-| `TEAMS_AUTO`             | Set to `true` to enable auto-login (macOS + FIDO2)                    |
-| `TEAMS_LOGIN`            | Set to `true` to enable interactive browser login                     |
-| `TEAMS_DEBUG_PORT`       | Chrome debug port (default: 9222)                                     |
-| `TEAMS_EDIT_REPLY_GUARD` | Edit reply guard: `allow` (default), `warn`, or `block`. See below    |
-| `TEAMS_AGENT_MARKER`     | Agent marker prefix for sent/edited messages (e.g. `Ⓜ`). See below   |
-| `TEAMS_DELETE_MODE`      | Delete mode: `hard` (default), `soft`, or `block`. See below          |
-| `TEAMS_DELETE_TOMBSTONE` | Custom tombstone text for soft-delete mode. See below                 |
-| `TEAMS_AUDIT_LOG`        | Audit logging: `off` (default), `stderr`, or `file:<path>`. See below |
+| Variable                        | Description                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------- |
+| `TEAMS_TOKEN`                   | Pre-existing skype token                                                               |
+| `TEAMS_BEARER_TOKEN`            | Optional middle-tier bearer token                                                      |
+| `TEAMS_SUBSTRATE_TOKEN`         | Optional Substrate bearer token                                                        |
+| `TEAMS_REGION`                  | API region override. Required with `TEAMS_TOKEN`; optional otherwise                   |
+| `TEAMS_EMAIL`                   | Corporate email. Optional — the server prompts the AI agent if needed                  |
+| `TEAMS_AUTO`                    | Set to `true` to enable auto-login (macOS + FIDO2)                                     |
+| `TEAMS_LOGIN`                   | Set to `true` to enable interactive browser login                                      |
+| `TEAMS_DEBUG_PORT`              | Chrome debug port (default: 9222)                                                      |
+| `TEAMS_EDIT_REPLY_GUARD`        | Edit reply guard: `allow` (default), `warn`, or `block`. See below                     |
+| `TEAMS_AGENT_MARKER`            | Agent marker prefix for sent/edited messages (e.g. `Ⓜ`). See below                    |
+| `TEAMS_DELETE_MODE`             | Delete mode: `hard` (default), `soft`, or `block`. See below                           |
+| `TEAMS_DELETE_TOMBSTONE`        | Custom tombstone text for soft-delete mode. See below                                  |
+| `TEAMS_AUDIT_LOG`               | Audit logging: `off` (default), `stderr`, or `file:<path>`. See below                  |
+| `TEAMS_PROTECTED_CONVERSATIONS` | Comma-separated glob patterns of conversations where edit/delete is blocked. See below |
 
 #### Agent marker
 
@@ -478,6 +479,22 @@ Each event is a single JSON line with the following fields:
 | `content`           | New content for edits, tombstone text for soft-delete, `null` for hard delete |
 
 Audit logging is designed to be silent — errors in the audit pipeline never affect tool execution.
+
+#### Protected conversations
+
+Some conversations contain sensitive or compliance-relevant information where accidental edits or deletions could be harmful. The `TEAMS_PROTECTED_CONVERSATIONS` environment variable (or `--protected-conversations` CLI flag / `protectedConversations` MCP parameter) blocks edit and delete actions in matching conversations:
+
+```jsonc
+{
+  "env": {
+    "TEAMS_PROTECTED_CONVERSATIONS": "Incident *,*compliance*,Architecture Decisions",
+  },
+}
+```
+
+Patterns are comma-separated and support `*` as a wildcard (matches any characters). Matching is case-insensitive. When a conversation's name matches any pattern, both `edit-message` and `delete-message` throw an error before making any changes — the message is left untouched.
+
+The per-call parameter takes precedence over the environment variable, so individual tool invocations can override the configured patterns when needed.
 
 ### Available tools
 

--- a/src/actions/message-actions.ts
+++ b/src/actions/message-actions.ts
@@ -26,6 +26,10 @@ import {
   resolveConversationId,
 } from "./conversation-resolution.js";
 import { emitAuditEvent } from "../audit.js";
+import {
+  resolveProtectedPatterns,
+  matchProtectedConversation,
+} from "../conversation-protection.js";
 
 /** Map file extension to MIME content type. */
 function contentTypeFromExtension(filePath: string): string {
@@ -584,12 +588,34 @@ export const editMessageAction: ActionDefinition = {
         "Defaults to TEAMS_AGENT_MARKER env var. Omit or set to empty to disable.",
       required: false,
     },
+    {
+      name: "protectedConversations",
+      type: "string",
+      description:
+        "Comma-separated glob patterns of conversation names where editing is blocked. " +
+        '`*` matches any characters, matching is case-insensitive. Example: "Architecture *,*compliance*". ' +
+        "Defaults to TEAMS_PROTECTED_CONVERSATIONS env var. Omit to allow all.",
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     const { conversationId, label } = await resolveConversationId(
       client,
       parameters,
     );
+
+    const protectedPatterns = resolveProtectedPatterns(
+      parameters.protectedConversations as string | undefined,
+    );
+    const matchedPattern = matchProtectedConversation(label, protectedPatterns);
+    if (matchedPattern) {
+      throw new Error(
+        `Cannot edit message in "${label}": conversation is protected ` +
+          `(matched pattern "${matchedPattern}"). ` +
+          `Remove the pattern from TEAMS_PROTECTED_CONVERSATIONS or the protectedConversations parameter to allow editing.`,
+      );
+    }
+
     const messageId = parameters.messageId as string;
     const agentMarker =
       (parameters.agentMarker as string | undefined) ??
@@ -697,12 +723,34 @@ export const deleteMessageAction: ActionDefinition = {
         `"${DEFAULT_DELETE_TOMBSTONE}".`,
       required: false,
     },
+    {
+      name: "protectedConversations",
+      type: "string",
+      description:
+        "Comma-separated glob patterns of conversation names where deletion is blocked. " +
+        '`*` matches any characters, matching is case-insensitive. Example: "Architecture *,*compliance*". ' +
+        "Defaults to TEAMS_PROTECTED_CONVERSATIONS env var. Omit to allow all.",
+      required: false,
+    },
   ],
   execute: async (client, parameters) => {
     const { conversationId, label } = await resolveConversationId(
       client,
       parameters,
     );
+
+    const protectedPatterns = resolveProtectedPatterns(
+      parameters.protectedConversations as string | undefined,
+    );
+    const matchedPattern = matchProtectedConversation(label, protectedPatterns);
+    if (matchedPattern) {
+      throw new Error(
+        `Cannot delete message in "${label}": conversation is protected ` +
+          `(matched pattern "${matchedPattern}"). ` +
+          `Remove the pattern from TEAMS_PROTECTED_CONVERSATIONS or the protectedConversations parameter to allow deletion.`,
+      );
+    }
+
     const messageId = parameters.messageId as string;
 
     const deleteMode: DeleteMode =

--- a/src/conversation-protection.ts
+++ b/src/conversation-protection.ts
@@ -1,0 +1,52 @@
+/**
+ * Conversation protection — restricts edit/delete in sensitive conversations.
+ *
+ * Reads `TEAMS_PROTECTED_CONVERSATIONS` (comma-separated glob patterns).
+ * When a conversation label matches any pattern, edit and delete actions
+ * are blocked with an informative error.
+ *
+ * Glob wildcards: `*` matches any characters. Matching is case-insensitive.
+ */
+
+/**
+ * Parse the `TEAMS_PROTECTED_CONVERSATIONS` env var (or a raw string)
+ * into a trimmed array of non-empty patterns.
+ */
+export function resolveProtectedPatterns(
+  raw?: string | null,
+): readonly string[] {
+  const value = raw ?? process.env.TEAMS_PROTECTED_CONVERSATIONS ?? "";
+  return value
+    .split(",")
+    .map((pattern) => pattern.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Convert a glob pattern (supporting `*`) into a case-insensitive RegExp.
+ *
+ * Every character except `*` is escaped; `*` becomes `.*`.
+ */
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, (character) =>
+    character === "*" ? ".*" : `\\${character}`,
+  );
+  return new RegExp(`^${escaped}$`, "i");
+}
+
+/**
+ * Check whether a conversation label matches any of the protected patterns.
+ *
+ * Returns the first matching pattern, or `undefined` if no match.
+ */
+export function matchProtectedConversation(
+  conversationLabel: string,
+  patterns: readonly string[],
+): string | undefined {
+  for (const pattern of patterns) {
+    if (globToRegExp(pattern).test(conversationLabel)) {
+      return pattern;
+    }
+  }
+  return undefined;
+}

--- a/tests/unit/conversation-protection.test.ts
+++ b/tests/unit/conversation-protection.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Unit tests for conversation protection (src/conversation-protection.ts).
+ *
+ * Tests pattern resolution, glob matching, and integration with
+ * edit/delete actions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  resolveProtectedPatterns,
+  matchProtectedConversation,
+} from "../../src/conversation-protection.js";
+import { actions } from "../../src/actions/definitions.js";
+import type { TeamsClient } from "../../src/teams-client.js";
+import type {
+  Conversation,
+  EditedMessage,
+  DeletedMessage,
+} from "../../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getAction(name: string) {
+  const action = actions.find((a) => a.name === name);
+  if (!action) throw new Error(`Action "${name}" not found`);
+  return action;
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "19:test@thread.space",
+    topic: "Architecture Decisions",
+    threadType: "chat",
+    version: 1,
+    lastMessageTime: "2026-03-16T10:00:00.000Z",
+    memberCount: 5,
+    ...overrides,
+  };
+}
+
+function createMockClient(
+  overrides: Partial<Record<keyof TeamsClient, unknown>> = {},
+): TeamsClient {
+  return {
+    listConversations: vi.fn(),
+    findConversation: vi.fn(),
+    findOneOnOneConversation: vi.fn(),
+    findPeople: vi.fn(),
+    findChats: vi.fn(),
+    getMessages: vi.fn(),
+    getMessagesPage: vi.fn(),
+    sendMessage: vi.fn(),
+    sendMessageWithImages: vi.fn(),
+    sendMessageWithFiles: vi.fn(),
+    editMessage: vi.fn(),
+    checkForReplies: vi
+      .fn()
+      .mockResolvedValue({ hasReplies: false, replyCount: 0 }),
+    deleteMessage: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    scheduleMessage: vi.fn(),
+    getMembers: vi.fn(),
+    getCurrentUserDisplayName: vi.fn(),
+    getToken: vi.fn(() => ({ skypeToken: "test-token", region: "apac" })),
+    setEmail: vi.fn(),
+    ...overrides,
+  } as unknown as TeamsClient;
+}
+
+// ── resolveProtectedPatterns ─────────────────────────────────────────
+
+describe("resolveProtectedPatterns", () => {
+  beforeEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+  });
+
+  it("returns empty array when no env var and no parameter", () => {
+    expect(resolveProtectedPatterns()).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(resolveProtectedPatterns("")).toEqual([]);
+  });
+
+  it("parses a single pattern", () => {
+    expect(resolveProtectedPatterns("Architecture *")).toEqual([
+      "Architecture *",
+    ]);
+  });
+
+  it("parses multiple comma-separated patterns", () => {
+    expect(
+      resolveProtectedPatterns("Architecture *,*compliance*,Incident *"),
+    ).toEqual(["Architecture *", "*compliance*", "Incident *"]);
+  });
+
+  it("trims whitespace from patterns", () => {
+    expect(
+      resolveProtectedPatterns("  Architecture * , *compliance* , Incident * "),
+    ).toEqual(["Architecture *", "*compliance*", "Incident *"]);
+  });
+
+  it("filters out empty segments", () => {
+    expect(resolveProtectedPatterns("Pattern A,,Pattern B,")).toEqual([
+      "Pattern A",
+      "Pattern B",
+    ]);
+  });
+
+  it("reads from TEAMS_PROTECTED_CONVERSATIONS env var when no parameter", () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *,*audit*";
+    expect(resolveProtectedPatterns()).toEqual(["Incident *", "*audit*"]);
+  });
+
+  it("parameter overrides env var", () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "from-env";
+    expect(resolveProtectedPatterns("from-param")).toEqual(["from-param"]);
+  });
+
+  it("null parameter falls back to env var", () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "from-env";
+    expect(resolveProtectedPatterns(null)).toEqual(["from-env"]);
+  });
+});
+
+// ── matchProtectedConversation ───────────────────────────────────────
+
+describe("matchProtectedConversation", () => {
+  it("returns undefined when patterns array is empty", () => {
+    expect(matchProtectedConversation("Any Chat", [])).toBeUndefined();
+  });
+
+  it("matches exact conversation name", () => {
+    expect(
+      matchProtectedConversation("Architecture Decisions", [
+        "Architecture Decisions",
+      ]),
+    ).toBe("Architecture Decisions");
+  });
+
+  it("matches with leading wildcard", () => {
+    expect(
+      matchProtectedConversation("Q4 Compliance Review", ["*compliance*"]),
+    ).toBe("*compliance*");
+  });
+
+  it("matches with trailing wildcard", () => {
+    expect(
+      matchProtectedConversation("Incident Response Team", ["Incident *"]),
+    ).toBe("Incident *");
+  });
+
+  it("matches with wildcards on both sides", () => {
+    expect(matchProtectedConversation("2026 Audit Results", ["*audit*"])).toBe(
+      "*audit*",
+    );
+  });
+
+  it("matching is case-insensitive", () => {
+    expect(
+      matchProtectedConversation("architecture decisions", ["Architecture *"]),
+    ).toBe("Architecture *");
+  });
+
+  it("returns the first matching pattern", () => {
+    expect(
+      matchProtectedConversation("Architecture Audit", [
+        "Architecture *",
+        "*Audit*",
+      ]),
+    ).toBe("Architecture *");
+  });
+
+  it("returns undefined when no patterns match", () => {
+    expect(
+      matchProtectedConversation("General Chat", [
+        "Architecture *",
+        "*compliance*",
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("handles special regex characters in conversation name", () => {
+    expect(
+      matchProtectedConversation("Team (2026) Compliance", ["Team (2026) *"]),
+    ).toBe("Team (2026) *");
+  });
+
+  it("handles special regex characters in pattern", () => {
+    expect(matchProtectedConversation("test.topic", ["test.topic"])).toBe(
+      "test.topic",
+    );
+  });
+
+  it("does not partially match", () => {
+    expect(
+      matchProtectedConversation("Architecture Decisions Extra", [
+        "Architecture Decisions",
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+// ── edit-message integration ─────────────────────────────────────────
+
+describe("edit-message conversation protection", () => {
+  const editAction = getAction("edit-message");
+
+  beforeEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_AGENT_MARKER;
+    delete process.env.TEAMS_EDIT_REPLY_GUARD;
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_AGENT_MARKER;
+    delete process.env.TEAMS_EDIT_REPLY_GUARD;
+  });
+
+  it("blocks edit in a protected conversation (env var)", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Architecture *";
+    const conversation = makeConversation({
+      topic: "Architecture Decisions",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn<() => Promise<EditedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+        editTime: "2026-04-12T10:00:00Z",
+      }),
+    });
+
+    await expect(
+      editAction.execute(client, {
+        chat: "Architecture Decisions",
+        messageId: "msg-1",
+        content: "Updated content",
+      }),
+    ).rejects.toThrow(/conversation is protected/);
+
+    expect(client.editMessage).not.toHaveBeenCalled();
+  });
+
+  it("blocks edit in a protected conversation (parameter override)", async () => {
+    const conversation = makeConversation({
+      topic: "Architecture Decisions",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn<() => Promise<EditedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+        editTime: "2026-04-12T10:00:00Z",
+      }),
+    });
+
+    await expect(
+      editAction.execute(client, {
+        chat: "Architecture Decisions",
+        messageId: "msg-1",
+        content: "Updated content",
+        protectedConversations: "Architecture *",
+      }),
+    ).rejects.toThrow(/conversation is protected/);
+
+    expect(client.editMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows edit when conversation does not match protected patterns", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Architecture *";
+    const conversation = makeConversation({
+      topic: "General Chat",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn<() => Promise<EditedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+        editTime: "2026-04-12T10:00:00Z",
+      }),
+    });
+
+    const result = await editAction.execute(client, {
+      chat: "General Chat",
+      messageId: "msg-1",
+      content: "Updated content",
+    });
+
+    expect(client.editMessage).toHaveBeenCalled();
+    expect(result).toHaveProperty("messageId", "msg-1");
+  });
+
+  it("allows edit when no protected patterns are configured", async () => {
+    const conversation = makeConversation({
+      topic: "Architecture Decisions",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn<() => Promise<EditedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+        editTime: "2026-04-12T10:00:00Z",
+      }),
+    });
+
+    const result = await editAction.execute(client, {
+      chat: "Architecture Decisions",
+      messageId: "msg-1",
+      content: "Updated content",
+    });
+
+    expect(client.editMessage).toHaveBeenCalled();
+    expect(result).toHaveProperty("messageId", "msg-1");
+  });
+
+  it("error message includes conversation name and matched pattern", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "*compliance*";
+    const conversation = makeConversation({
+      topic: "Q4 Compliance Review",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    await expect(
+      editAction.execute(client, {
+        chat: "Q4 Compliance Review",
+        messageId: "msg-1",
+        content: "new",
+      }),
+    ).rejects.toThrow(
+      /Cannot edit message in "Q4 Compliance Review".*matched pattern "\*compliance\*"/,
+    );
+  });
+});
+
+// ── delete-message integration ───────────────────────────────────────
+
+describe("delete-message conversation protection", () => {
+  const deleteAction = getAction("delete-message");
+
+  beforeEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_DELETE_MODE;
+    delete process.env.TEAMS_DELETE_TOMBSTONE;
+  });
+
+  afterEach(() => {
+    delete process.env.TEAMS_PROTECTED_CONVERSATIONS;
+    delete process.env.TEAMS_AUDIT_LOG;
+    delete process.env.TEAMS_DELETE_MODE;
+    delete process.env.TEAMS_DELETE_TOMBSTONE;
+  });
+
+  it("blocks hard delete in a protected conversation", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *";
+    const conversation = makeConversation({
+      topic: "Incident Response 2026-04-12",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      deleteMessage: vi.fn<() => Promise<DeletedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+      }),
+    });
+
+    await expect(
+      deleteAction.execute(client, {
+        chat: "Incident Response 2026-04-12",
+        messageId: "msg-1",
+      }),
+    ).rejects.toThrow(/conversation is protected/);
+
+    expect(client.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("blocks soft delete in a protected conversation", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *";
+    const conversation = makeConversation({
+      topic: "Incident Response 2026-04-12",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      editMessage: vi.fn<() => Promise<EditedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+        editTime: "2026-04-12T10:00:00Z",
+      }),
+    });
+
+    await expect(
+      deleteAction.execute(client, {
+        chat: "Incident Response 2026-04-12",
+        messageId: "msg-1",
+        deleteMode: "soft",
+      }),
+    ).rejects.toThrow(/conversation is protected/);
+
+    expect(client.editMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows delete when conversation does not match protected patterns", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *";
+    const conversation = makeConversation({
+      topic: "General Chat",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      deleteMessage: vi.fn<() => Promise<DeletedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+      }),
+    });
+
+    const result = await deleteAction.execute(client, {
+      chat: "General Chat",
+      messageId: "msg-1",
+    });
+
+    expect(client.deleteMessage).toHaveBeenCalled();
+    expect(result).toHaveProperty("messageId", "msg-1");
+  });
+
+  it("allows delete when no protected patterns are configured", async () => {
+    const conversation = makeConversation({
+      topic: "Incident Response 2026-04-12",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+      deleteMessage: vi.fn<() => Promise<DeletedMessage>>().mockResolvedValue({
+        messageId: "msg-1",
+      }),
+    });
+
+    const result = await deleteAction.execute(client, {
+      chat: "Incident Response 2026-04-12",
+      messageId: "msg-1",
+    });
+
+    expect(client.deleteMessage).toHaveBeenCalled();
+    expect(result).toHaveProperty("messageId", "msg-1");
+  });
+
+  it("error message includes conversation name and matched pattern", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *";
+    const conversation = makeConversation({
+      topic: "Incident Response 2026-04-12",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    await expect(
+      deleteAction.execute(client, {
+        chat: "Incident Response 2026-04-12",
+        messageId: "msg-1",
+      }),
+    ).rejects.toThrow(
+      /Cannot delete message in "Incident Response 2026-04-12".*matched pattern "Incident \*"/,
+    );
+  });
+
+  it("protection check runs before deleteMode check", async () => {
+    process.env.TEAMS_PROTECTED_CONVERSATIONS = "Incident *";
+    const conversation = makeConversation({
+      topic: "Incident Response",
+    });
+    const client = createMockClient({
+      findConversation: vi.fn().mockResolvedValue(conversation),
+    });
+
+    // Even with deleteMode "block", the protection error should fire first
+    await expect(
+      deleteAction.execute(client, {
+        chat: "Incident Response",
+        messageId: "msg-1",
+        deleteMode: "block",
+      }),
+    ).rejects.toThrow(/conversation is protected/);
+  });
+});


### PR DESCRIPTION
Ⓜ

## Summary

Implements configurable conversation protection — blocking edit and delete actions in sensitive conversations. Closes #30.

## Changes

- **`src/conversation-protection.ts`** — new module with `resolveProtectedPatterns()` and `matchProtectedConversation()`. Parses comma-separated glob patterns (`*` wildcard, case-insensitive matching).
- **`src/actions/message-actions.ts`** — added `protectedConversations` parameter and protection check to both `editMessageAction` and `deleteMessageAction`. Check runs after conversation resolution but before any mutation.
- **`tests/unit/conversation-protection.test.ts`** — 31 tests covering pattern parsing, glob matching, and integration with edit/delete actions.
- **`README.md`** — added `TEAMS_PROTECTED_CONVERSATIONS` env var to the table and a new "Protected conversations" documentation section.

## Configuration

```jsonc
{
  "env": {
    "TEAMS_PROTECTED_CONVERSATIONS": "Incident *,*compliance*,Architecture Decisions"
  }
}
```

Per-call parameter (`protectedConversations`) overrides the env var.