### PR TITLE
fix: add entities as direct dependency for npx compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^14.0.3",
+        "entities": "^4.5.0",
         "markdown-it": "^14.1.1",
         "playwright": "^1.58.2",
         "puppeteer-core": "^24.39.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^14.0.3",
+    "entities": "^4.5.0",
     "markdown-it": "^14.1.1",
     "playwright": "^1.58.2",
     "puppeteer-core": "^24.39.1",


### PR DESCRIPTION
Ⓜ

## Problem

When running `npx -y -p teams-api@latest teams-api-mcp` on Node.js v24.15.0 (Windows), the `entities` package (a transitive dependency of `markdown-it`) fails to resolve:

```
Error: Cannot find module 'entities'
Require stack:
- .../node_modules/markdown-it/dist/index.cjs.js
- .../node_modules/teams-api/dist/api/chat-service.js
```

## Fix

Add `entities` as a direct dependency (`^4.5.0`, matching `markdown-it`'s requirement). This ensures it is always hoisted to the top-level `node_modules` where `markdown-it`'s CJS bundle can find it via `require('entities')`.

## Testing

- All 675 unit tests pass
- Build succeeds
- Type check passes