### PR TITLE
fix: add ajv as direct dependency for MCP runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "ajv": "^8.18.0",
         "commander": "^14.0.3",
         "entities": "^4.5.0",
         "markdown-it": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "ajv": "^8.18.0",
     "commander": "^14.0.3",
     "entities": "^4.5.0",
     "markdown-it": "^14.1.1",


### PR DESCRIPTION
## Summary
- add `ajv` as a direct dependency in `package.json`
- keep `package-lock.json` root dependency list in sync

## Why
Running the MCP server via `npx` could fail with:
`Error: Cannot find module 'ajv'`

Adding `ajv` as a direct dependency makes runtime resolution robust in `npx` install/cache environments.

## Validation
- `npm install`
- `npm run build`
- verified no editor diagnostics