### PR TITLE
Add Teams image description action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ src/
     middle-tier.ts      Middle-tier profile and presence lookups
     substrate.ts        Substrate search API (people, chats)
     transcripts.ts      VTT transcript fetching and parsing
+    image-description.ts  OpenAI-compatible vision endpoint integration
   auth/
     auto-login.ts       Auto-login via system Chrome + FIDO2 passkey
     debug-session.ts    CDP debug session token capture
@@ -75,6 +76,7 @@ src/
     definitions.ts      Action registry — imports and assembles all actions
     conversation-actions.ts  List, find, and 1:1 conversation actions
     message-actions.ts       Get, send, edit, delete message actions
+    image-description-actions.ts  Describe image action
     search-actions.ts        People and chat search actions
     utility-actions.ts       Whoami, get-members, get-transcript actions
     formatters.ts       Output formatting utilities and type definitions

--- a/README.md
+++ b/README.md
@@ -511,9 +511,22 @@ All MCP tools accept an optional `format` parameter (`concise` or `detailed`). D
 | `teams_send_message`       | Send a message to a conversation                      |
 | `teams_get_members`        | List members of a conversation                        |
 | `teams_get_transcript`     | Get a meeting transcript from a recorded conversation |
+| `teams_download_file`      | Download message files and inline images              |
+| `teams_describe_image`     | Describe an inline Teams image with a vision model    |
 | `teams_whoami`             | Get the authenticated user's display name             |
 
 Workflow guidance, tips, and important notes are served automatically via the MCP server's `instructions` field — no separate skill file needed. For the same content on the CLI, run `teams-api guide`.
+
+### Image descriptions
+
+`teams_describe_image` reuses the existing Teams AMS image download support and sends the image bytes to an OpenAI-compatible vision endpoint. Configure it with `TEAMS_IMAGE_DESCRIPTION_API_KEY` or `OPENAI_API_KEY`. Optional overrides: `TEAMS_IMAGE_DESCRIPTION_MODEL` and `TEAMS_IMAGE_DESCRIPTION_BASE_URL`.
+
+Examples:
+
+```bash
+teams-api describe-image --chat "Project Chat" --message-id 1773736076914 --image-index 0
+teams-api describe-image --ams-object-id 0-eaua-d2-877b82634f4e978692f2243d445a6650
+```
 
 ## API regions
 

--- a/server.json
+++ b/server.json
@@ -83,6 +83,24 @@
           "description": "Override the telemetry output file path (default: platform-appropriate ~/Library/... or ~/.local/share/...)",
           "isRequired": false,
           "isSecret": false
+        },
+        {
+          "name": "TEAMS_IMAGE_DESCRIPTION_API_KEY",
+          "description": "API key for the OpenAI-compatible vision endpoint used by teams_describe_image",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "TEAMS_IMAGE_DESCRIPTION_MODEL",
+          "description": "Model name for teams_describe_image (defaults to gpt-4o-mini)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "TEAMS_IMAGE_DESCRIPTION_BASE_URL",
+          "description": "OpenAI-compatible base URL for teams_describe_image",
+          "isRequired": false,
+          "isSecret": false
         }
       ]
     }

--- a/src/actions/definitions.ts
+++ b/src/actions/definitions.ts
@@ -23,6 +23,7 @@ import {
 import { findPeopleAction, findChatsAction } from "./search-actions.js";
 import { getMembers, whoami, getTranscript } from "./utility-actions.js";
 import { downloadFileAction } from "./file-actions.js";
+import { describeImageAction } from "./image-description-actions.js";
 
 // ── Registry ─────────────────────────────────────────────────────────
 
@@ -47,6 +48,7 @@ const actionRegistry = new Map<string, ActionDefinition>([
   ["whoami", whoami],
   ["get-transcript", getTranscript],
   ["download-file", downloadFileAction],
+  ["describe-image", describeImageAction],
 ]);
 
 /** All registered actions, derived from the registry map. */

--- a/src/actions/image-description-actions.ts
+++ b/src/actions/image-description-actions.ts
@@ -1,0 +1,216 @@
+/**
+ * Image description action definitions.
+ *
+ * Actions: describe-image.
+ */
+
+import type { ImageAttachment } from "../types.js";
+import { describeImageWithOpenAiCompatibleVision } from "../api/image-description.js";
+import { type ActionDefinition } from "./formatters.js";
+import {
+  conversationParameters,
+  resolveConversationId,
+} from "./conversation-resolution.js";
+
+export const ImageDescriptionSourceType = {
+  AmsObject: "ams-object",
+  Message: "message",
+} as const;
+
+export type ImageDescriptionSourceType =
+  (typeof ImageDescriptionSourceType)[keyof typeof ImageDescriptionSourceType];
+
+export interface DescribeImageResult {
+  description: string;
+  provider: string;
+  model: string;
+  image: {
+    sourceType: ImageDescriptionSourceType;
+    amsObjectId: string;
+    contentType: string;
+    size: number;
+    messageId?: string;
+    imageIndex?: number;
+    width?: number | null;
+    height?: number | null;
+  };
+}
+
+interface ImageTarget {
+  sourceType: ImageDescriptionSourceType;
+  amsObjectId: string;
+  messageId?: string;
+  imageIndex?: number;
+  width?: number | null;
+  height?: number | null;
+}
+
+function resolveImageIndex(value: number | undefined): number {
+  const imageIndex = value ?? 0;
+  if (!Number.isInteger(imageIndex) || imageIndex < 0) {
+    throw new Error("imageIndex must be a non-negative integer.");
+  }
+  return imageIndex;
+}
+
+function resolveMessageImage(
+  images: ImageAttachment[],
+  imageIndex: number,
+): ImageAttachment {
+  const image = images[imageIndex];
+  if (!image) {
+    throw new Error(
+      `Message image index ${imageIndex} is out of range; the message has ${images.length} image(s).`,
+    );
+  }
+  return image;
+}
+
+async function resolveImageTarget(
+  client: Parameters<ActionDefinition["execute"]>[0],
+  parameters: Record<string, unknown>,
+): Promise<ImageTarget> {
+  const amsObjectId = parameters.amsObjectId as string | undefined;
+  if (amsObjectId) {
+    return {
+      sourceType: ImageDescriptionSourceType.AmsObject,
+      amsObjectId,
+    };
+  }
+
+  const messageId = parameters.messageId as string | undefined;
+  if (!messageId) {
+    throw new Error(
+      "Provide either amsObjectId, or messageId plus chat/to/conversationId.",
+    );
+  }
+
+  const { conversationId } = await resolveConversationId(client, parameters);
+  const messages = await client.getMessages(conversationId);
+  const message = messages.find((candidate) => candidate.id === messageId);
+  if (!message) {
+    throw new Error(
+      `Message ${messageId} not found in conversation ${conversationId}`,
+    );
+  }
+
+  if (message.images.length === 0) {
+    throw new Error(`Message ${messageId} has no inline images.`);
+  }
+
+  const imageIndex = resolveImageIndex(parameters.imageIndex as number);
+  const image = resolveMessageImage(message.images, imageIndex);
+
+  return {
+    sourceType: ImageDescriptionSourceType.Message,
+    amsObjectId: image.amsObjectId,
+    messageId,
+    imageIndex,
+    width: image.width,
+    height: image.height,
+  };
+}
+
+export const describeImageAction: ActionDefinition = {
+  name: "describe-image",
+  title: "Describe Image",
+  description:
+    "Describe an inline Teams image using a configured OpenAI-compatible vision model. " +
+    "Use amsObjectId directly, or identify a message by chat/to/conversationId plus messageId. " +
+    "Set TEAMS_IMAGE_DESCRIPTION_API_KEY or OPENAI_API_KEY before using this tool.",
+  parameters: [
+    ...conversationParameters,
+    {
+      name: "messageId",
+      type: "string",
+      description:
+        "ID of the message containing the image. Required unless amsObjectId is provided.",
+      required: false,
+    },
+    {
+      name: "imageIndex",
+      type: "number",
+      description:
+        "Zero-based index of the inline image within the message (default: 0).",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "amsObjectId",
+      type: "string",
+      description:
+        "Direct AMS object ID for an inline Teams image. When provided, conversation and message lookup are skipped.",
+      required: false,
+    },
+    {
+      name: "fullSize",
+      type: "boolean",
+      description:
+        "Download the full-size AMS image before describing it (default: true).",
+      required: false,
+      default: true,
+    },
+    {
+      name: "prompt",
+      type: "string",
+      description:
+        "Optional custom instruction for the vision model. Defaults to a concise Teams-context description prompt.",
+      required: false,
+    },
+  ],
+  execute: async (client, parameters) => {
+    const imageTarget = await resolveImageTarget(client, parameters);
+    const fullSize = (parameters.fullSize as boolean | undefined) ?? true;
+    const imageData = await client.downloadImage(
+      imageTarget.amsObjectId,
+      fullSize,
+    );
+    const descriptionResult = await describeImageWithOpenAiCompatibleVision({
+      imageData: imageData.data,
+      contentType: imageData.contentType,
+      prompt: parameters.prompt as string | undefined,
+    });
+
+    return {
+      description: descriptionResult.description,
+      provider: descriptionResult.provider,
+      model: descriptionResult.model,
+      image: {
+        ...imageTarget,
+        contentType: imageData.contentType,
+        size: imageData.size,
+      },
+    } satisfies DescribeImageResult;
+  },
+  formatConcise: (result) => {
+    const descriptionResult = result as DescribeImageResult;
+    const lines = [
+      "## Image description",
+      "",
+      descriptionResult.description,
+      "",
+      `- Provider: ${descriptionResult.provider}`,
+      `- Model: ${descriptionResult.model}`,
+      `- AMS object ID: ${descriptionResult.image.amsObjectId}`,
+      `- Content type: ${descriptionResult.image.contentType}`,
+      `- Size: ${descriptionResult.image.size} bytes`,
+    ];
+
+    if (descriptionResult.image.messageId) {
+      lines.push(`- Message ID: ${descriptionResult.image.messageId}`);
+    }
+    if (descriptionResult.image.imageIndex !== undefined) {
+      lines.push(`- Image index: ${descriptionResult.image.imageIndex}`);
+    }
+    if (
+      descriptionResult.image.width !== undefined &&
+      descriptionResult.image.height !== undefined
+    ) {
+      lines.push(
+        `- Dimensions: ${descriptionResult.image.width ?? "unknown"} x ${descriptionResult.image.height ?? "unknown"}`,
+      );
+    }
+
+    return lines.join("\n");
+  },
+};

--- a/src/api/image-description.ts
+++ b/src/api/image-description.ts
@@ -1,0 +1,127 @@
+/**
+ * Image description utilities.
+ *
+ * The Teams API provides image bytes; this module sends those bytes to an
+ * OpenAI-compatible vision endpoint when the user has configured credentials.
+ */
+
+import { fetchWithRetry } from "./common.js";
+
+const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_OPENAI_COMPATIBLE_MODEL = "gpt-4o-mini";
+const DEFAULT_IMAGE_DESCRIPTION_PROMPT =
+  "Describe this Teams image for someone who cannot see it. Focus on visible text, UI state, diagrams, charts, and any actionable context. Be concise but complete.";
+
+interface ImageDescriptionConfig {
+  endpointUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface DescribeImageOptions {
+  imageData: Buffer;
+  contentType: string;
+  prompt?: string;
+  environment?: NodeJS.ProcessEnv;
+  fetchFunction?: typeof fetch;
+}
+
+export interface ImageDescriptionResult {
+  provider: "openai-compatible";
+  model: string;
+  description: string;
+}
+
+interface OpenAiCompatibleVisionResponse {
+  choices?: Array<{
+    message?: {
+      content?: string | null;
+    };
+  }>;
+}
+
+function readImageDescriptionConfig(
+  environment: NodeJS.ProcessEnv,
+): ImageDescriptionConfig {
+  const apiKey =
+    environment.TEAMS_IMAGE_DESCRIPTION_API_KEY ?? environment.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Image description requires TEAMS_IMAGE_DESCRIPTION_API_KEY or OPENAI_API_KEY to be set.",
+    );
+  }
+
+  const baseUrl = (
+    environment.TEAMS_IMAGE_DESCRIPTION_BASE_URL ??
+    DEFAULT_OPENAI_COMPATIBLE_BASE_URL
+  ).replace(/\/+$/, "");
+  const model =
+    environment.TEAMS_IMAGE_DESCRIPTION_MODEL ??
+    DEFAULT_OPENAI_COMPATIBLE_MODEL;
+
+  return {
+    endpointUrl: `${baseUrl}/chat/completions`,
+    apiKey,
+    model,
+  };
+}
+
+export async function describeImageWithOpenAiCompatibleVision(
+  options: DescribeImageOptions,
+): Promise<ImageDescriptionResult> {
+  const environment = options.environment ?? process.env;
+  const fetchFunction = options.fetchFunction ?? fetchWithRetry;
+  const config = readImageDescriptionConfig(environment);
+  const prompt = options.prompt ?? DEFAULT_IMAGE_DESCRIPTION_PROMPT;
+
+  const response = await fetchFunction(config.endpointUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: config.model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: prompt,
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: `data:${options.contentType};base64,${options.imageData.toString("base64")}`,
+              },
+            },
+          ],
+        },
+      ],
+      max_tokens: 500,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Image description request failed: ${response.status} ${response.statusText} — ${errorText}`,
+    );
+  }
+
+  const responseBody =
+    (await response.json()) as OpenAiCompatibleVisionResponse;
+  const description = responseBody.choices?.[0]?.message?.content?.trim();
+  if (!description) {
+    throw new Error(
+      "Image description response did not include message content.",
+    );
+  }
+
+  return {
+    provider: "openai-compatible",
+    model: config.model,
+    description,
+  };
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,6 +17,7 @@
  *     TEAMS_LOGIN           — Set to "true" to use interactive browser login (all platforms)
  *     TEAMS_DEBUG_PORT      — Chrome debug port (default: 9222)
  *     TEAMS_TELEMETRY       — Set to "true" to enable full debug telemetry (contributor use)
+ *     TEAMS_IMAGE_DESCRIPTION_API_KEY — Optional vision API key for teams_describe_image
  *
  * Usage in VS Code settings (mcp config):
  *   {

--- a/src/server-instructions.ts
+++ b/src/server-instructions.ts
@@ -52,6 +52,10 @@ Call teams_find_people to search the organization directory by name. Call teams_
 
 Call teams_get_transcript with chat: "Meeting Name" to retrieve the parsed transcript, or pass rawVtt: true for the original VTT file.
 
+### Describe an inline image
+
+Call teams_describe_image with chat/to/conversationId plus messageId to describe an inline Teams image, or pass amsObjectId directly if you already have it. The tool requires TEAMS_IMAGE_DESCRIPTION_API_KEY or OPENAI_API_KEY for an OpenAI-compatible vision endpoint.
+
 ## Important notes
 
 - Most tools accept chat, to, or conversationId to identify a conversation. You only need one — the server resolves the rest automatically.

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -177,6 +177,11 @@ export {
   createSharePointSharingLink,
 } from "./api/attachments.js";
 export type { SharePointUploadResult } from "./api/attachments.js";
+export { describeImageWithOpenAiCompatibleVision } from "./api/image-description.js";
+export type {
+  DescribeImageOptions,
+  ImageDescriptionResult,
+} from "./api/image-description.js";
 export { saveToken, loadToken, clearToken } from "./token-store.js";
 export { actions } from "./actions/definitions.js";
 export { formatOutput } from "./actions/formatters.js";

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -9,13 +9,14 @@
  *   - Parameter definitions are complete and consistent
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { actions } from "../../src/actions/definitions.js";
 import { formatOutput } from "../../src/actions/formatters.js";
 import type {
   ActionDefinition,
   OutputFormat,
 } from "../../src/actions/formatters.js";
+import type { DescribeImageResult } from "../../src/actions/image-description-actions.js";
 import type { TeamsClient } from "../../src/teams-client.js";
 import type {
   Conversation,
@@ -57,6 +58,8 @@ function createMockClient(
     getMembers: vi.fn(),
     getCurrentUserDisplayName: vi.fn(),
     getToken: vi.fn(() => ({ skypeToken: "test-token", region: "apac" })),
+    downloadFile: vi.fn(),
+    downloadImage: vi.fn(),
     setEmail: vi.fn(),
     ...overrides,
   } as unknown as TeamsClient;
@@ -119,8 +122,8 @@ beforeEach(() => {
 // ── Registry tests ───────────────────────────────────────────────────
 
 describe("action registry", () => {
-  it("should contain all 15 actions", () => {
-    expect(actions).toHaveLength(15);
+  it("should contain all 16 actions", () => {
+    expect(actions).toHaveLength(16);
   });
 
   it("should have unique names", () => {
@@ -161,6 +164,7 @@ describe("action registry", () => {
     expect(names).toContain("get-members");
     expect(names).toContain("whoami");
     expect(names).toContain("get-transcript");
+    expect(names).toContain("describe-image");
   });
 });
 
@@ -2830,6 +2834,188 @@ describe("download-file", () => {
   });
 });
 
+// ── Describe image ───────────────────────────────────────────────────
+
+describe("describe-image", () => {
+  const describeImageAction = getAction("describe-image");
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  function mockVisionResponse(description: string): ReturnType<typeof vi.fn> {
+    const fetchFunction = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: description } }],
+        }),
+      text: () => Promise.resolve(""),
+    });
+    globalThis.fetch = fetchFunction;
+    return fetchFunction;
+  }
+
+  it("should describe an inline image from a message", async () => {
+    vi.stubEnv("TEAMS_IMAGE_DESCRIPTION_API_KEY", "test-api-key");
+    vi.stubEnv("TEAMS_IMAGE_DESCRIPTION_MODEL", "vision-test-model");
+    const fetchFunction = mockVisionResponse(
+      "A dialog showing a validation warning.",
+    );
+    const imageData = Buffer.from("fake-image-data");
+    const client = createMockClient({
+      getMessages: vi.fn().mockResolvedValue([
+        makeMessage({
+          id: "msg-1",
+          images: [
+            {
+              amsObjectId: "ams-1",
+              url: "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-1/views/imgo",
+              fullSizeUrl:
+                "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-1/views/imgpsh_fullsize_anim",
+              width: 400,
+              height: 300,
+              contentPosition: 0,
+            },
+            {
+              amsObjectId: "ams-2",
+              url: "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-2/views/imgo",
+              fullSizeUrl:
+                "https://as-prod.asyncgw.teams.microsoft.com/v1/objects/ams-2/views/imgpsh_fullsize_anim",
+              width: 800,
+              height: 600,
+              contentPosition: 50,
+            },
+          ],
+        }),
+      ]),
+      downloadImage: vi.fn().mockResolvedValue({
+        data: imageData,
+        contentType: "image/png",
+        size: imageData.length,
+      }),
+    });
+
+    const result = (await describeImageAction.execute(client, {
+      conversationId: "19:test@thread.space",
+      messageId: "msg-1",
+      imageIndex: 1,
+    })) as DescribeImageResult;
+
+    expect(client.getMessages).toHaveBeenCalledWith("19:test@thread.space");
+    expect(client.downloadImage).toHaveBeenCalledWith("ams-2", true);
+    expect(fetchFunction).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-api-key",
+        }),
+      }),
+    );
+    const requestBody = JSON.parse(
+      fetchFunction.mock.calls[0][1].body as string,
+    ) as {
+      model: string;
+      messages: Array<{
+        content: Array<{ type: string; image_url?: { url: string } }>;
+      }>;
+    };
+    expect(requestBody.model).toBe("vision-test-model");
+    expect(requestBody.messages[0].content[1].image_url?.url).toBe(
+      `data:image/png;base64,${imageData.toString("base64")}`,
+    );
+    expect(result.description).toBe("A dialog showing a validation warning.");
+    expect(result.image).toMatchObject({
+      sourceType: "message",
+      amsObjectId: "ams-2",
+      messageId: "msg-1",
+      imageIndex: 1,
+      width: 800,
+      height: 600,
+      contentType: "image/png",
+      size: imageData.length,
+    });
+  });
+
+  it("should describe a direct AMS object without fetching messages", async () => {
+    vi.stubEnv("TEAMS_IMAGE_DESCRIPTION_API_KEY", "test-api-key");
+    mockVisionResponse("A screenshot of a table.");
+    const client = createMockClient({
+      getMessages: vi.fn(),
+      downloadImage: vi.fn().mockResolvedValue({
+        data: Buffer.from("image"),
+        contentType: "image/jpeg",
+        size: 5,
+      }),
+    });
+
+    const result = (await describeImageAction.execute(client, {
+      amsObjectId: "ams-direct",
+      fullSize: false,
+    })) as DescribeImageResult;
+
+    expect(client.getMessages).not.toHaveBeenCalled();
+    expect(client.downloadImage).toHaveBeenCalledWith("ams-direct", false);
+    expect(result.image.sourceType).toBe("ams-object");
+  });
+
+  it("should require image description credentials", async () => {
+    const client = createMockClient({
+      downloadImage: vi.fn().mockResolvedValue({
+        data: Buffer.from("image"),
+        contentType: "image/png",
+        size: 5,
+      }),
+    });
+
+    await expect(
+      describeImageAction.execute(client, { amsObjectId: "ams-direct" }),
+    ).rejects.toThrow("TEAMS_IMAGE_DESCRIPTION_API_KEY or OPENAI_API_KEY");
+  });
+
+  it("should throw when a message has no inline images", async () => {
+    vi.stubEnv("TEAMS_IMAGE_DESCRIPTION_API_KEY", "test-api-key");
+    const client = createMockClient({
+      getMessages: vi.fn().mockResolvedValue([makeMessage({ id: "msg-1" })]),
+    });
+
+    await expect(
+      describeImageAction.execute(client, {
+        conversationId: "19:test@thread.space",
+        messageId: "msg-1",
+      }),
+    ).rejects.toThrow("Message msg-1 has no inline images.");
+  });
+
+  it("formatConcise should include description and source metadata", () => {
+    const output = describeImageAction.formatConcise({
+      description: "A screenshot of a chart.",
+      provider: "openai-compatible",
+      model: "vision-test-model",
+      image: {
+        sourceType: "message",
+        amsObjectId: "ams-1",
+        contentType: "image/png",
+        size: 42,
+        messageId: "msg-1",
+        imageIndex: 0,
+        width: 640,
+        height: 480,
+      },
+    } satisfies DescribeImageResult);
+
+    expect(output).toContain("A screenshot of a chart.");
+    expect(output).toContain("AMS object ID: ams-1");
+    expect(output).toContain("Message ID: msg-1");
+    expect(output).toContain("Dimensions: 640 x 480");
+  });
+});
+
 // ── Parametrized structural validation across all actions ────────────
 
 describe("action registry (parametrized)", () => {
@@ -2849,6 +3035,7 @@ describe("action registry (parametrized)", () => {
     "whoami",
     "get-transcript",
     "download-file",
+    "describe-image",
   ];
 
   it("should contain exactly the expected actions", () => {

--- a/tests/unit/image-description.test.ts
+++ b/tests/unit/image-description.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { describeImageWithOpenAiCompatibleVision } from "../../src/api/image-description.js";
+
+describe("describeImageWithOpenAiCompatibleVision", () => {
+  it("should call an OpenAI-compatible vision endpoint", async () => {
+    const fetchFunction = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "A screenshot of a task board." } }],
+        }),
+      text: () => Promise.resolve(""),
+    });
+    const imageData = Buffer.from("image-bytes");
+
+    const result = await describeImageWithOpenAiCompatibleVision({
+      imageData,
+      contentType: "image/png",
+      prompt: "Describe the UI.",
+      environment: {
+        TEAMS_IMAGE_DESCRIPTION_API_KEY: "test-key",
+        TEAMS_IMAGE_DESCRIPTION_BASE_URL: "https://vision.example.test/v1/",
+        TEAMS_IMAGE_DESCRIPTION_MODEL: "vision-model",
+      } as NodeJS.ProcessEnv,
+      fetchFunction,
+    });
+
+    expect(result).toEqual({
+      provider: "openai-compatible",
+      model: "vision-model",
+      description: "A screenshot of a task board.",
+    });
+    expect(fetchFunction).toHaveBeenCalledWith(
+      "https://vision.example.test/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    const requestBody = JSON.parse(
+      fetchFunction.mock.calls[0][1].body as string,
+    ) as {
+      messages: Array<{
+        content: Array<{
+          text?: string;
+          image_url?: {
+            url: string;
+          };
+        }>;
+      }>;
+    };
+    expect(requestBody.messages[0].content[0].text).toBe("Describe the UI.");
+    expect(requestBody.messages[0].content[1].image_url?.url).toBe(
+      `data:image/png;base64,${imageData.toString("base64")}`,
+    );
+  });
+
+  it("should throw when no API key is configured", async () => {
+    await expect(
+      describeImageWithOpenAiCompatibleVision({
+        imageData: Buffer.from("image"),
+        contentType: "image/png",
+        environment: {} as NodeJS.ProcessEnv,
+        fetchFunction: vi.fn(),
+      }),
+    ).rejects.toThrow("TEAMS_IMAGE_DESCRIPTION_API_KEY or OPENAI_API_KEY");
+  });
+
+  it("should surface provider error responses", async () => {
+    const fetchFunction = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      text: () => Promise.resolve("rate limited"),
+    });
+
+    await expect(
+      describeImageWithOpenAiCompatibleVision({
+        imageData: Buffer.from("image"),
+        contentType: "image/png",
+        environment: {
+          TEAMS_IMAGE_DESCRIPTION_API_KEY: "test-key",
+        } as NodeJS.ProcessEnv,
+        fetchFunction,
+      }),
+    ).rejects.toThrow(
+      "Image description request failed: 429 Too Many Requests",
+    );
+  });
+});


### PR DESCRIPTION
Ⓜ

## Summary

Adds a `describe-image` action exposed as `teams_describe_image` in MCP so agents can generate text descriptions for Teams inline images from either a message image or a direct AMS object ID.

## Changes

- Added OpenAI-compatible vision request support with `TEAMS_IMAGE_DESCRIPTION_*` configuration.
- Added CLI/MCP action plumbing, concise output formatting, public exports, and MCP server env docs.
- Documented usage in README/server instructions and covered the behavior with unit tests.

Closes #17