### PR TITLE
Prefer Chat Service tokens during login

### DIFF
--- a/src/auth/interactive.ts
+++ b/src/auth/interactive.ts
@@ -50,11 +50,11 @@ export async function acquireTokenViaInteractiveLogin(
     profileDir,
   );
 
-  // Close leftover tabs from previous sessions, then open a fresh page
-  for (const stale of context.pages()) {
-    await stale.close();
+  const existingPages = context.pages();
+  const page = existingPages[0] ?? (await context.newPage());
+  for (const stalePage of existingPages.slice(1)) {
+    await stalePage.close();
   }
-  const page = await context.newPage();
 
   try {
     log("Navigating to Teams...");
@@ -122,6 +122,7 @@ export async function acquireTokenViaInteractiveLogin(
       substrateToken,
       amsToken,
       sharePointToken,
+      sharePointHost,
     } = await captureTokensFromPage(page, log, TOKEN_INTERCEPT_TIMEOUT);
 
     return {
@@ -131,6 +132,7 @@ export async function acquireTokenViaInteractiveLogin(
       substrateToken,
       amsToken,
       sharePointToken,
+      sharePointHost,
     };
   } finally {
     await context.close();

--- a/src/auth/token-capture.ts
+++ b/src/auth/token-capture.ts
@@ -14,6 +14,24 @@ export const PAGE_STATE_POLL_INTERVAL = 3 * 1_000;
 
 export type LogFunction = (...arguments_: unknown[]) => void;
 
+const FALLBACK_SKYPE_TOKEN_GRACE_PERIOD = 5 * 1_000;
+
+function isChatServiceRequest(requestUrl: string): boolean {
+  try {
+    const url = new URL(requestUrl);
+    return url.hostname.toLowerCase().endsWith(".ng.msg.teams.microsoft.com");
+  } catch {
+    return false;
+  }
+}
+
+function normalizeSkypeTokenHeader(value: string): string {
+  const prefix = "skypetoken=";
+  return value.toLowerCase().startsWith(prefix)
+    ? value.slice(prefix.length)
+    : value;
+}
+
 /**
  * Wait for the page to reach Teams and capture authentication tokens via CDP.
  *
@@ -47,6 +65,7 @@ export async function captureTokensFromPage(
     detach: () => Promise<void>;
   };
   let skypeToken: string | null = null;
+  let fallbackSkypeToken: string | null = null;
   let region: string | null = null;
   let bearerToken: string | null = null;
   let substrateToken: string | null = null;
@@ -63,8 +82,42 @@ export async function captureTokensFromPage(
   const tokenPromise = new Promise<void>((resolve) => {
     const timeout = setTimeout(() => {
       log("Token intercept timed out");
+      if (fallbackTimeout) {
+        clearTimeout(fallbackTimeout);
+      }
+      if (!skypeToken && fallbackSkypeToken) {
+        skypeToken = fallbackSkypeToken;
+        log("Using fallback Skype token from non-chat request headers");
+      }
       resolve();
     }, interceptTimeout);
+    let fallbackTimeout: NodeJS.Timeout | null = null;
+
+    function resolveWithToken(): void {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      if (fallbackTimeout) {
+        clearTimeout(fallbackTimeout);
+      }
+      log("Skype token captured from request headers");
+      clearTimeout(timeout);
+      resolve();
+    }
+
+    function scheduleFallbackResolution(): void {
+      if (fallbackTimeout) {
+        return;
+      }
+      fallbackTimeout = setTimeout(() => {
+        if (!skypeToken && fallbackSkypeToken) {
+          skypeToken = fallbackSkypeToken;
+          log("Using fallback Skype token from non-chat request headers");
+          resolveWithToken();
+        }
+      }, FALLBACK_SKYPE_TOKEN_GRACE_PERIOD);
+    }
 
     cdpSession.on(
       "Fetch.requestPaused",
@@ -75,16 +128,23 @@ export async function captureTokensFromPage(
         };
         const requestId = event.requestId as string;
         const requestUrl = request.url ?? "";
+        const isChatService = isChatServiceRequest(requestUrl);
         const detectedRegion = detectTeamsRegionFromUrl(requestUrl);
 
-        if (detectedRegion && !region) {
+        if (detectedRegion && (isChatService || !region)) {
           region = detectedRegion;
           log(`Detected Teams region from request URL: ${region}`);
         }
 
         for (const [name, value] of Object.entries(request.headers ?? {})) {
-          if (name.toLowerCase() === "x-skypetoken" && !skypeToken) {
-            skypeToken = value;
+          if (name.toLowerCase() === "x-skypetoken") {
+            const normalizedToken = normalizeSkypeTokenHeader(value);
+            if (isChatService && !skypeToken) {
+              skypeToken = normalizedToken;
+            } else if (!fallbackSkypeToken) {
+              fallbackSkypeToken = normalizedToken;
+              scheduleFallbackResolution();
+            }
           }
           if (
             name.toLowerCase() === "authorization" &&
@@ -108,11 +168,8 @@ export async function captureTokensFromPage(
           // Request may have already been handled
         }
 
-        if (skypeToken && !resolved) {
-          resolved = true;
-          log("Skype token captured from request headers");
-          clearTimeout(timeout);
-          resolve();
+        if (skypeToken) {
+          resolveWithToken();
         }
       },
     );

--- a/tests/unit/token-capture.test.ts
+++ b/tests/unit/token-capture.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { captureTokensFromPage } from "../../src/auth/token-capture.js";
+
+interface FetchRequestPausedEvent {
+  requestId: string;
+  request: {
+    url: string;
+    headers: Record<string, string>;
+  };
+}
+
+function createPageStub(events: FetchRequestPausedEvent[]) {
+  let requestPausedHandler:
+    | ((event: FetchRequestPausedEvent) => Promise<void>)
+    | null = null;
+
+  const devToolsSession = {
+    send: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(
+      (
+        eventName: string,
+        handler: (event: FetchRequestPausedEvent) => Promise<void>,
+      ) => {
+        if (eventName === "Fetch.requestPaused") {
+          requestPausedHandler = handler;
+        }
+      },
+    ),
+    detach: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const page = {
+    context: () => ({
+      newCDPSession: vi.fn().mockResolvedValue(devToolsSession),
+    }),
+    reload: vi.fn(async () => {
+      if (!requestPausedHandler) {
+        throw new Error("Fetch.requestPaused handler was not registered");
+      }
+      for (const event of events) {
+        await requestPausedHandler(event);
+      }
+    }),
+    evaluate: vi.fn().mockResolvedValue({}),
+    url: () => "https://teams.cloud.microsoft/v2/",
+  };
+
+  return { page, devToolsSession };
+}
+
+describe("captureTokensFromPage", () => {
+  it("prefers a Chat Service Skype token over earlier Teams web requests", async () => {
+    const { page } = createPageStub([
+      {
+        requestId: "web-request",
+        request: {
+          url: "https://teams.cloud.microsoft/api/mt/amer/beta/users/fetchShortProfile",
+          headers: {
+            "x-skypetoken": "web-token",
+            authorization: "Bearer bearer-token",
+          },
+        },
+      },
+      {
+        requestId: "substrate-request",
+        request: {
+          url: "https://substrate.office.com/search/api/v1/suggestions?scenario=peoplepicker.newChat",
+          headers: {
+            authorization: "Bearer substrate-token",
+          },
+        },
+      },
+      {
+        requestId: "chat-service-request",
+        request: {
+          url: "https://emea.ng.msg.teams.microsoft.com/v1/users/ME/conversations",
+          headers: {
+            "x-skypetoken": "skypetoken=chat-service-token",
+          },
+        },
+      },
+    ]);
+
+    const token = await captureTokensFromPage(page, vi.fn(), 30_000);
+
+    expect(token.skypeToken).toBe("chat-service-token");
+    expect(token.region).toBe("emea");
+    expect(token.bearerToken).toBe("bearer-token");
+    expect(token.substrateToken).toBe("substrate-token");
+  });
+});


### PR DESCRIPTION
Ⓜ

## Summary

- Prefer `x-skypetoken` values captured from Chat Service requests over earlier Teams web/middle-tier requests.
- Let Chat Service requests override earlier region detection so the captured token and API region stay aligned.
- Reuse an existing persistent-context page during interactive login instead of closing every page before opening a new one, avoiding a Windows/Edge `Target.createTarget` failure path.
- Preserve the captured SharePoint host from interactive login.

Related to #50.

## Validation

- `npm test`
- `npm run type-check`
- `npm run build`
- `npm run format`
- `npm run format-check`
