### PR TITLE
Fix resolution of old one-on-one chats

### DIFF
--- a/src/api/chat-service.ts
+++ b/src/api/chat-service.ts
@@ -21,7 +21,7 @@ import type {
   ReactionResult,
   ScheduledMessage,
 } from "../types.js";
-import { fetchWithRetry, ApiAuthError } from "./common.js";
+import { fetchWithRetry, ApiAuthError, ApiResponseError } from "./common.js";
 import { parseInlineImages, parseFileAttachments } from "./attachments.js";
 import MarkdownIt from "markdown-it";
 
@@ -141,8 +141,9 @@ export async function fetchMembers(
         `Authentication failed: ${response.status} ${response.statusText}`,
       );
     }
-    throw new Error(
+    throw new ApiResponseError(
       `Failed to fetch members: ${response.status} ${response.statusText}`,
+      response.status,
     );
   }
 

--- a/src/api/chat-service.ts
+++ b/src/api/chat-service.ts
@@ -597,56 +597,6 @@ export async function removeReaction(
 }
 
 /**
- * Create a new 1:1 conversation with a given member, or return the existing one.
- *
- * Uses `PUT /users/ME/conversations` with a single member MRI.
- * A 201 response means the conversation was created; a 200 response (or 409 on
- * some server versions) means it already existed — both return the conversation ID.
- */
-export async function createOneOnOneConversation(
-  token: TeamsToken,
-  memberMri: string,
-): Promise<{ id: string }> {
-  if (!memberMri || !/^8:orgid:[0-9a-f-]+$/i.test(memberMri)) {
-    throw new Error(
-      `Invalid member MRI for 1:1 conversation creation: "${memberMri}". Expected format: 8:orgid:{uuid}`,
-    );
-  }
-
-  const url = `${chatServiceBase(token.region)}/users/ME/conversations`;
-  const response = await fetchWithRetry(url, {
-    method: "PUT",
-    headers: {
-      ...authHeaders(token),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      members: [{ mri: memberMri, role: "Admin" }],
-    }),
-  });
-
-  // 200 = already exists, 201 = newly created, 409 = conflict / already exists
-  if (!response.ok && response.status !== 409) {
-    if (response.status === 401) {
-      throw new ApiAuthError(
-        `Authentication failed: ${response.status} ${response.statusText}`,
-      );
-    }
-    throw new Error(
-      `Failed to create conversation: ${response.status} ${response.statusText}`,
-    );
-  }
-
-  const data = (await response.json()) as { id?: string };
-  if (!data.id) {
-    throw new Error(
-      "No conversation ID returned when creating 1:1 conversation",
-    );
-  }
-  return { id: data.id };
-}
-
-/**
  * Fetch user properties for the authenticated user.
  * Returns raw properties — display name may or may not be present.
  */

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -22,6 +22,16 @@ export class ApiRateLimitError extends Error {
   }
 }
 
+export class ApiResponseError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "ApiResponseError";
+    this.statusCode = statusCode;
+  }
+}
+
 const MAX_RETRY_ATTEMPTS = 5;
 const INITIAL_BACKOFF_MILLISECONDS = 2_000;
 

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -72,7 +72,6 @@ import {
   removeReaction,
   postScheduledMessage,
   fetchUserProperties,
-  createOneOnOneConversation,
 } from "./api/chat-service.js";
 import { ApiAuthError, ApiRateLimitError } from "./api/common.js";
 import { resolveReactionKey, initializeEmojiMap } from "./emoji-map.js";
@@ -112,6 +111,19 @@ function extractEmailFromToken(token: TeamsToken): string | undefined {
       Buffer.from(jwt.split(".")[1], "base64").toString("utf-8"),
     ) as { upn?: string };
     return payload.upn ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractObjectIdFromToken(token: TeamsToken): string | undefined {
+  const bearerToken = token.bearerToken;
+  if (!bearerToken) return undefined;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(bearerToken.split(".")[1], "base64").toString("utf-8"),
+    ) as { oid?: string };
+    return payload.oid ?? undefined;
   } catch {
     return undefined;
   }
@@ -889,7 +901,7 @@ export class TeamsClient {
       }
 
       // Strategy 1: Substrate search API for people + chat lookup
-      let matchedPersonForCreation:
+      let matchedPersonForConversation:
         | { mri: string; displayName: string }
         | undefined;
       try {
@@ -899,14 +911,10 @@ export class TeamsClient {
         );
 
         if (matchedPerson) {
-          // Validate MRI early — an invalid/empty MRI would cause both the UUID
-          // match below and createOneOnOneConversation to misbehave.
+          // Validate MRI early because both conversation lookup and virtual ID
+          // construction require an organization user UUID.
           if (/^8:orgid:[0-9a-f-]+$/i.test(matchedPerson.mri)) {
-            // Tentatively mark this person for conversation creation.  This is
-            // set before the chat search so that a searchChats failure (5xx /
-            // network error) doesn't silently prevent us from falling back to
-            // the idempotent create call further below.
-            matchedPersonForCreation = matchedPerson;
+            matchedPersonForConversation = matchedPerson;
           }
 
           // Try to find an existing chat via Substrate search.
@@ -936,8 +944,7 @@ export class TeamsClient {
           }
 
           // Check if any conversation ID contains the person's UUID.
-          // This only covers the 100 most-recent conversations; old 1:1 chats
-          // that no longer appear here are handled by createOneOnOneConversation.
+          // This only covers the 100 most-recent conversations.
           const personUuid = matchedPerson.mri.replace("8:orgid:", "");
           const matchingConversation = conversations.find(
             (conversation) =>
@@ -950,6 +957,33 @@ export class TeamsClient {
               memberDisplayName: matchedPerson.displayName,
             };
           }
+
+          const currentUserObjectId = extractObjectIdFromToken(this.token);
+          if (currentUserObjectId && matchedPersonForConversation) {
+            const matchedPersonMri = matchedPersonForConversation.mri;
+            const candidateConversationIds = [
+              `19:${currentUserObjectId}_${personUuid}@unq.gbl.spaces`,
+              `19:${personUuid}_${currentUserObjectId}@unq.gbl.spaces`,
+            ];
+            for (const candidateConversationId of candidateConversationIds) {
+              try {
+                const members = await fetchMembers(
+                  this.token,
+                  candidateConversationId,
+                );
+                if (members.some((member) => member.id === matchedPersonMri)) {
+                  return {
+                    conversationId: candidateConversationId,
+                    memberDisplayName: matchedPerson.displayName,
+                  };
+                }
+              } catch (error) {
+                if (error instanceof ApiAuthError) {
+                  throw error;
+                }
+              }
+            }
+          }
         }
       } catch (error) {
         if (error instanceof ApiAuthError) {
@@ -960,7 +994,7 @@ export class TeamsClient {
 
       // Fallback person discovery: scan group chat members and resolve
       // via profiles when Substrate search is unavailable.
-      if (!matchedPersonForCreation) {
+      if (!matchedPersonForConversation) {
         try {
           const memberMris = new Set<string>();
 
@@ -1013,7 +1047,7 @@ export class TeamsClient {
               matchedProfile &&
               /^8:orgid:[0-9a-f-]+$/i.test(matchedProfile.mri)
             ) {
-              matchedPersonForCreation = {
+              matchedPersonForConversation = {
                 displayName: matchedProfile.displayName,
                 mri: matchedProfile.mri,
               };
@@ -1041,17 +1075,20 @@ export class TeamsClient {
         }
       }
 
-      // If substrate search identified the person but found no existing chat, create one.
-      // This handles the case of first-ever contact with someone in the org.
-      if (matchedPersonForCreation) {
-        const newConversation = await createOneOnOneConversation(
-          this.token,
-          matchedPersonForCreation.mri,
-        );
-        return {
-          conversationId: newConversation.id,
-          memberDisplayName: matchedPersonForCreation.displayName,
-        };
+      // New 1:1 chats use a deterministic virtual ID. Teams persists the
+      // conversation when its first message is sent.
+      if (matchedPersonForConversation) {
+        const currentUserObjectId = extractObjectIdFromToken(this.token);
+        if (currentUserObjectId) {
+          const targetUserObjectId = matchedPersonForConversation.mri.replace(
+            "8:orgid:",
+            "",
+          );
+          return {
+            conversationId: `19:${currentUserObjectId}_${targetUserObjectId}@unq.gbl.spaces`,
+            memberDisplayName: matchedPersonForConversation.displayName,
+          };
+        }
       }
 
       // Strategy 2: Profile-based matching for 1:1 chats (uses Bearer token)

--- a/src/teams-client.ts
+++ b/src/teams-client.ts
@@ -73,7 +73,11 @@ import {
   postScheduledMessage,
   fetchUserProperties,
 } from "./api/chat-service.js";
-import { ApiAuthError, ApiRateLimitError } from "./api/common.js";
+import {
+  ApiAuthError,
+  ApiRateLimitError,
+  ApiResponseError,
+} from "./api/common.js";
 import { resolveReactionKey, initializeEmojiMap } from "./emoji-map.js";
 import { fetchProfiles } from "./api/middle-tier.js";
 import { searchPeople, searchChats } from "./api/substrate.js";
@@ -957,33 +961,6 @@ export class TeamsClient {
               memberDisplayName: matchedPerson.displayName,
             };
           }
-
-          const currentUserObjectId = extractObjectIdFromToken(this.token);
-          if (currentUserObjectId && matchedPersonForConversation) {
-            const matchedPersonMri = matchedPersonForConversation.mri;
-            const candidateConversationIds = [
-              `19:${currentUserObjectId}_${personUuid}@unq.gbl.spaces`,
-              `19:${personUuid}_${currentUserObjectId}@unq.gbl.spaces`,
-            ];
-            for (const candidateConversationId of candidateConversationIds) {
-              try {
-                const members = await fetchMembers(
-                  this.token,
-                  candidateConversationId,
-                );
-                if (members.some((member) => member.id === matchedPersonMri)) {
-                  return {
-                    conversationId: candidateConversationId,
-                    memberDisplayName: matchedPerson.displayName,
-                  };
-                }
-              } catch (error) {
-                if (error instanceof ApiAuthError) {
-                  throw error;
-                }
-              }
-            }
-          }
         }
       } catch (error) {
         if (error instanceof ApiAuthError) {
@@ -1072,6 +1049,48 @@ export class TeamsClient {
             authError = error;
           }
           // Profile-based fallback failed — continue to other strategies
+        }
+      }
+
+      if (matchedPersonForConversation) {
+        const currentUserObjectId = extractObjectIdFromToken(this.token);
+        if (currentUserObjectId) {
+          const matchedPersonMri = matchedPersonForConversation.mri;
+          const matchedPersonObjectId = matchedPersonMri.replace(
+            "8:orgid:",
+            "",
+          );
+          const candidateConversationIds = [
+            `19:${currentUserObjectId}_${matchedPersonObjectId}@unq.gbl.spaces`,
+            `19:${matchedPersonObjectId}_${currentUserObjectId}@unq.gbl.spaces`,
+          ];
+          for (const candidateConversationId of candidateConversationIds) {
+            try {
+              const members = await fetchMembers(
+                this.token,
+                candidateConversationId,
+              );
+              if (
+                members.some(
+                  (member) =>
+                    member.id.toLowerCase() === matchedPersonMri.toLowerCase(),
+                )
+              ) {
+                return {
+                  conversationId: candidateConversationId,
+                  memberDisplayName: matchedPersonForConversation.displayName,
+                };
+              }
+            } catch (error) {
+              if (
+                error instanceof ApiResponseError &&
+                error.statusCode === 404
+              ) {
+                continue;
+              }
+              throw error;
+            }
+          }
         }
       }
 

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -19,7 +19,11 @@ import {
   fetchUserProperties,
   parseRawMessage,
 } from "../../src/api/chat-service.js";
-import { ApiAuthError, ApiRateLimitError } from "../../src/api/common.js";
+import {
+  ApiAuthError,
+  ApiRateLimitError,
+  ApiResponseError,
+} from "../../src/api/common.js";
 import { fetchProfiles } from "../../src/api/middle-tier.js";
 import { searchPeople, searchChats } from "../../src/api/substrate.js";
 import {
@@ -252,6 +256,17 @@ describe("fetchMembers", () => {
 
     expect(members[0].memberType).toBe("person");
     expect(members[1].memberType).toBe("bot");
+  });
+
+  it("should expose the response status when member lookup fails", async () => {
+    mockFetchResponse({}, 404);
+
+    await expect(fetchMembers(testToken, "missing-chat")).rejects.toMatchObject(
+      {
+        name: "ApiResponseError",
+        statusCode: 404,
+      } satisfies Partial<ApiResponseError>,
+    );
   });
 });
 

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -12,7 +12,7 @@ import * as chatService from "../../src/api/chat-service.js";
 import * as middleTier from "../../src/api/middle-tier.js";
 import * as substrate from "../../src/api/substrate.js";
 import * as attachments from "../../src/api/attachments.js";
-import { ApiAuthError } from "../../src/api/common.js";
+import { ApiAuthError, ApiResponseError } from "../../src/api/common.js";
 import * as tokenStore from "../../src/token-store.js";
 import * as autoLogin from "../../src/auth/auto-login.js";
 import * as interactiveLogin from "../../src/auth/interactive.js";
@@ -534,7 +534,7 @@ describe("findOneOnOneConversation", () => {
     expect(result!.memberDisplayName).toBe("Alice Smith");
   });
 
-  it("should find an old 1:1 by verifying both deterministic conversation ID orderings", async () => {
+  it("should find an old 1:1 across both ID orderings and MRI casing", async () => {
     const currentUserObjectId = "11111111-1111-1111-1111-111111111111";
     const targetUserObjectId = "22222222-2222-2222-2222-222222222222";
     const currentUserMri = `8:orgid:${currentUserObjectId}`;
@@ -555,7 +555,9 @@ describe("findOneOnOneConversation", () => {
     ]);
     mockedApi.searchChats.mockResolvedValue([]);
     mockedApi.fetchMembers
-      .mockRejectedValueOnce(new Error("Conversation not found"))
+      .mockRejectedValueOnce(
+        new ApiResponseError("Conversation not found", 404),
+      )
       .mockResolvedValueOnce([
         {
           id: currentUserMri,
@@ -564,7 +566,7 @@ describe("findOneOnOneConversation", () => {
           memberType: "person",
         },
         {
-          id: targetUserMri,
+          id: targetUserMri.toUpperCase(),
           displayName: "Alice Smith",
           role: "Admin",
           memberType: "person",
@@ -592,6 +594,44 @@ describe("findOneOnOneConversation", () => {
       2,
       expect.anything(),
       targetUserFirstConversationId,
+    );
+  });
+
+  it("should propagate member lookup failures while verifying old 1:1 chats", async () => {
+    const currentUserObjectId = "11111111-1111-1111-1111-111111111111";
+    const targetUserObjectId = "22222222-2222-2222-2222-222222222222";
+
+    mockedApi.fetchConversations.mockResolvedValue([]);
+    mockedApi.searchPeople.mockResolvedValue([
+      {
+        displayName: "Alice Smith",
+        mri: `8:orgid:${targetUserObjectId}`,
+        email: "alice@example.com",
+        jobTitle: "Engineer",
+        department: "Development",
+        objectId: targetUserObjectId,
+      },
+    ]);
+    mockedApi.searchChats.mockResolvedValue([]);
+    mockedApi.fetchMembers.mockRejectedValue(
+      new ApiAuthError("Chat Service token expired"),
+    );
+
+    const client = TeamsClient.fromToken(
+      "token",
+      "apac",
+      makeBearerToken({ oid: currentUserObjectId }),
+      "substrate-token",
+    );
+
+    await expect(
+      client.findOneOnOneConversation("Alice"),
+    ).rejects.toBeInstanceOf(ApiAuthError);
+
+    mockedApi.fetchMembers.mockRejectedValue(new Error("Network unavailable"));
+
+    await expect(client.findOneOnOneConversation("Alice")).rejects.toThrow(
+      "Network unavailable",
     );
   });
 
@@ -664,7 +704,7 @@ describe("findOneOnOneConversation", () => {
     mockedApi.searchChats.mockResolvedValue([]);
 
     mockedApi.fetchMembers.mockRejectedValue(
-      new Error("Conversation not found"),
+      new ApiResponseError("Conversation not found", 404),
     );
 
     const client = TeamsClient.fromToken(
@@ -707,7 +747,7 @@ describe("findOneOnOneConversation", () => {
     mockedApi.searchChats.mockRejectedValue(new Error("Server error: 503"));
 
     mockedApi.fetchMembers.mockRejectedValue(
-      new Error("Conversation not found"),
+      new ApiResponseError("Conversation not found", 404),
     );
 
     const client = TeamsClient.fromToken(
@@ -877,7 +917,7 @@ describe("findOneOnOneConversation", () => {
     ).rejects.toBeInstanceOf(ApiAuthError);
   });
 
-  it("should find person via group chat member scanning when substrate returns empty", async () => {
+  it("should verify old 1:1 IDs after group member discovery", async () => {
     // No existing 1:1 conversations; only a group chat where Alice is a member
     mockedApi.fetchConversations.mockResolvedValue([
       makeConversation({
@@ -892,20 +932,38 @@ describe("findOneOnOneConversation", () => {
     mockedApi.searchChats.mockResolvedValue([]);
 
     // Group chat has Alice as a member
-    mockedApi.fetchMembers.mockResolvedValue([
-      {
-        id: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
-        displayName: "",
-        role: "member",
-        memberType: "person" as const,
-      },
-      {
-        id: "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
-        displayName: "",
-        role: "member",
-        memberType: "person" as const,
-      },
-    ]);
+    mockedApi.fetchMembers
+      .mockResolvedValueOnce([
+        {
+          id: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+          displayName: "",
+          role: "member",
+          memberType: "person" as const,
+        },
+        {
+          id: "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+          displayName: "",
+          role: "member",
+          memberType: "person" as const,
+        },
+      ])
+      .mockRejectedValueOnce(
+        new ApiResponseError("Conversation not found", 404),
+      )
+      .mockResolvedValueOnce([
+        {
+          id: "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+          displayName: "Current User",
+          role: "Admin",
+          memberType: "person" as const,
+        },
+        {
+          id: "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+          displayName: "Alice Smith",
+          role: "Admin",
+          memberType: "person" as const,
+        },
+      ]);
 
     // Profile resolution finds Alice
     mockedApi.fetchProfiles.mockResolvedValue([
@@ -937,7 +995,7 @@ describe("findOneOnOneConversation", () => {
 
     expect(result).not.toBeNull();
     expect(result!.conversationId).toBe(
-      "19:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5_f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0@unq.gbl.spaces",
+      "19:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5@unq.gbl.spaces",
     );
     expect(result!.memberDisplayName).toBe("Alice Smith");
     expect(mockedApi.fetchMembers).toHaveBeenCalled();

--- a/tests/unit/teams-client.test.ts
+++ b/tests/unit/teams-client.test.ts
@@ -40,7 +40,6 @@ vi.mock("../../src/api/chat-service.js", async (importOriginal) => {
     fetchUserProperties: vi.fn(),
     addReaction: vi.fn(),
     removeReaction: vi.fn(),
-    createOneOnOneConversation: vi.fn(),
   };
 });
 vi.mock("../../src/api/middle-tier.js", async (importOriginal) => {
@@ -140,6 +139,14 @@ function makeMessagesPage(
   backwardLink: string | null = null,
 ): MessagesPage {
   return { messages, backwardLink, syncState: null };
+}
+
+function makeBearerToken(payload: Record<string, unknown>): string {
+  return [
+    Buffer.from(JSON.stringify({ algorithm: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
 }
 
 const mockedEmojiMap = vi.mocked(emojiMap);
@@ -527,6 +534,67 @@ describe("findOneOnOneConversation", () => {
     expect(result!.memberDisplayName).toBe("Alice Smith");
   });
 
+  it("should find an old 1:1 by verifying both deterministic conversation ID orderings", async () => {
+    const currentUserObjectId = "11111111-1111-1111-1111-111111111111";
+    const targetUserObjectId = "22222222-2222-2222-2222-222222222222";
+    const currentUserMri = `8:orgid:${currentUserObjectId}`;
+    const targetUserMri = `8:orgid:${targetUserObjectId}`;
+    const currentUserFirstConversationId = `19:${currentUserObjectId}_${targetUserObjectId}@unq.gbl.spaces`;
+    const targetUserFirstConversationId = `19:${targetUserObjectId}_${currentUserObjectId}@unq.gbl.spaces`;
+
+    mockedApi.fetchConversations.mockResolvedValue([]);
+    mockedApi.searchPeople.mockResolvedValue([
+      {
+        displayName: "Alice Smith",
+        mri: targetUserMri,
+        email: "alice@example.com",
+        jobTitle: "Engineer",
+        department: "Development",
+        objectId: targetUserObjectId,
+      },
+    ]);
+    mockedApi.searchChats.mockResolvedValue([]);
+    mockedApi.fetchMembers
+      .mockRejectedValueOnce(new Error("Conversation not found"))
+      .mockResolvedValueOnce([
+        {
+          id: currentUserMri,
+          displayName: "Current User",
+          role: "Admin",
+          memberType: "person",
+        },
+        {
+          id: targetUserMri,
+          displayName: "Alice Smith",
+          role: "Admin",
+          memberType: "person",
+        },
+      ]);
+
+    const client = TeamsClient.fromToken(
+      "token",
+      "apac",
+      makeBearerToken({ oid: currentUserObjectId }),
+      "substrate-token",
+    );
+    const result = await client.findOneOnOneConversation("Alice");
+
+    expect(result).toEqual({
+      conversationId: targetUserFirstConversationId,
+      memberDisplayName: "Alice Smith",
+    });
+    expect(mockedApi.fetchMembers).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      currentUserFirstConversationId,
+    );
+    expect(mockedApi.fetchMembers).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      targetUserFirstConversationId,
+    );
+  });
+
   it("should fall back to message scanning when no substrate token", async () => {
     mockedApi.fetchConversations.mockResolvedValue([
       makeConversation({ id: "19:chat1", threadType: "chat", topic: "" }),
@@ -570,10 +638,9 @@ describe("findOneOnOneConversation", () => {
     const result = await client.findOneOnOneConversation("Nonexistent Person");
 
     expect(result).toBeNull();
-    expect(mockedApi.createOneOnOneConversation).not.toHaveBeenCalled();
   });
 
-  it("should create a new 1:1 conversation when person found via substrate but no existing chat", async () => {
+  it("should return a virtual 1:1 conversation ID when the person has no existing chat", async () => {
     // No pre-existing 1:1 conversations
     mockedApi.fetchConversations.mockResolvedValue([
       makeConversation({
@@ -596,15 +663,16 @@ describe("findOneOnOneConversation", () => {
     // No existing 1:1 chats in search results
     mockedApi.searchChats.mockResolvedValue([]);
 
-    // Create conversation returns a new ID
-    mockedApi.createOneOnOneConversation.mockResolvedValue({
-      id: "19:00000000-0000-0000-0000-000000000000_a1b2c3d4-e5f6-0000-0000-000000000000@unq.gbl.spaces",
-    });
+    mockedApi.fetchMembers.mockRejectedValue(
+      new Error("Conversation not found"),
+    );
 
     const client = TeamsClient.fromToken(
       "token",
       "apac",
-      "bearer",
+      makeBearerToken({
+        oid: "00000000-0000-0000-0000-000000000000",
+      }),
       "substrate-token",
     );
     const result = await client.findOneOnOneConversation("Alice");
@@ -614,17 +682,9 @@ describe("findOneOnOneConversation", () => {
       "19:00000000-0000-0000-0000-000000000000_a1b2c3d4-e5f6-0000-0000-000000000000@unq.gbl.spaces",
     );
     expect(result!.memberDisplayName).toBe("Alice Smith");
-    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalledWith(
-      expect.anything(),
-      "8:orgid:a1b2c3d4-e5f6-0000-0000-000000000000",
-    );
   });
 
-  it("should still create conversation when searchChats throws a non-auth error", async () => {
-    // This covers the case where an old 1:1 chat is not in the top 100 conversations
-    // AND the chat search API returns a 5xx error. Previously, the 5xx exception
-    // would abort the if(matchedPerson) block before matchedPersonForCreation was
-    // set, causing findOneOnOneConversation to return null instead of creating the chat.
+  it("should still return a virtual conversation ID when searchChats throws a non-auth error", async () => {
     mockedApi.fetchConversations.mockResolvedValue([
       makeConversation({
         id: "19:some-group@thread.v2",
@@ -646,14 +706,16 @@ describe("findOneOnOneConversation", () => {
     // searchChats throws a server error (5xx)
     mockedApi.searchChats.mockRejectedValue(new Error("Server error: 503"));
 
-    mockedApi.createOneOnOneConversation.mockResolvedValue({
-      id: "19:00000000-0000-0000-0000-000000000000_a1b2c3d4-e5f6-0000-0000-000000000000@unq.gbl.spaces",
-    });
+    mockedApi.fetchMembers.mockRejectedValue(
+      new Error("Conversation not found"),
+    );
 
     const client = TeamsClient.fromToken(
       "token",
       "apac",
-      "bearer",
+      makeBearerToken({
+        oid: "00000000-0000-0000-0000-000000000000",
+      }),
       "substrate-token",
     );
     const result = await client.findOneOnOneConversation("Alice");
@@ -662,7 +724,6 @@ describe("findOneOnOneConversation", () => {
     expect(result!.conversationId).toBe(
       "19:00000000-0000-0000-0000-000000000000_a1b2c3d4-e5f6-0000-0000-000000000000@unq.gbl.spaces",
     );
-    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalled();
   });
 
   it("should find existing 1:1 chat when searchChats returns lowercase threadType", async () => {
@@ -705,7 +766,6 @@ describe("findOneOnOneConversation", () => {
     expect(result).not.toBeNull();
     expect(result!.conversationId).toBe("19:alice-chat@unq.gbl.spaces");
     expect(result!.memberDisplayName).toBe("Alice Smith");
-    expect(mockedApi.createOneOnOneConversation).not.toHaveBeenCalled();
   });
 
   it("should fall back to profile-based matching when substrate search returns empty", async () => {
@@ -865,26 +925,21 @@ describe("findOneOnOneConversation", () => {
       },
     ]);
 
-    // Should create a new 1:1 conversation since none exists
-    mockedApi.createOneOnOneConversation.mockResolvedValue({
-      id: "19:new-1on1@unq.gbl.spaces",
-    });
-
     const client = TeamsClient.fromToken(
       "token",
       "apac",
-      "bearer",
+      makeBearerToken({
+        oid: "a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+      }),
       "substrate-token",
     );
     const result = await client.findOneOnOneConversation("Alice");
 
     expect(result).not.toBeNull();
-    expect(result!.conversationId).toBe("19:new-1on1@unq.gbl.spaces");
-    expect(result!.memberDisplayName).toBe("Alice Smith");
-    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalledWith(
-      expect.anything(),
-      "8:orgid:f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0",
+    expect(result!.conversationId).toBe(
+      "19:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5_f6f6f6f6-a7a7-b8b8-c9c9-d0d0d0d0d0d0@unq.gbl.spaces",
     );
+    expect(result!.memberDisplayName).toBe("Alice Smith");
     expect(mockedApi.fetchMembers).toHaveBeenCalled();
   });
 
@@ -924,19 +979,20 @@ describe("findOneOnOneConversation", () => {
       },
     ]);
 
-    mockedApi.createOneOnOneConversation.mockResolvedValue({
-      id: "19:new-convo@unq.gbl.spaces",
-    });
-
-    const client = TeamsClient.fromToken("token", "apac", "bearer");
+    const client = TeamsClient.fromToken(
+      "token",
+      "apac",
+      makeBearerToken({
+        oid: "11111111-1111-1111-1111-111111111111",
+      }),
+    );
     const result = await client.findOneOnOneConversation("Alice");
 
     expect(result).not.toBeNull();
-    expect(result!.memberDisplayName).toBe("Alice Smith");
-    expect(mockedApi.createOneOnOneConversation).toHaveBeenCalledWith(
-      expect.anything(),
-      "8:orgid:a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5",
+    expect(result!.conversationId).toBe(
+      "19:11111111-1111-1111-1111-111111111111_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5@unq.gbl.spaces",
     );
+    expect(result!.memberDisplayName).toBe("Alice Smith");
   });
 });
 


### PR DESCRIPTION
Ⓜ

## Summary

Resolve existing one-on-one chats even when they are absent from the recent conversation list or Substrate chat search.

- Derive both deterministic participant orderings from the current-user and target-user object IDs.
- Verify candidate thread IDs through the members endpoint before choosing an existing chat.
- Return the current-user-first virtual thread ID for a genuinely new contact, allowing the first send to persist it.
- Remove the unsupported eager `PUT /users/ME/conversations` call.
- Add regression coverage for old chats, reversed participant ordering, and new-contact fallback behavior.

## Validation

- `npm test`: 697 passed, 41 skipped
- `npm run type-check`
- `npm run build`
- `npm run format-check`
- Live functional test: resolved Cody Love's non-recent one-on-one by name, sent the AI Hub report, and read message `1784804614895` back successfully.