### PR TITLE
Omit binary blobs from MCP download responses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,23 +207,23 @@ Each `ActionDefinition` implements a single `formatConcise(result)` method that 
 
 Use this table as the review checklist for formatter changes.
 
-| Action               | Concise must include                                                      | Concise may summarize                                                            |
-| -------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `list-conversations` | Conversation ID, topic, thread type, last-message indicator               | Ancillary conversation metadata not needed for selecting a target conversation   |
-| `find-conversation`  | Conversation ID, thread type, topic                                       | Optional timestamps/nullable fields                                              |
-| `find-one-on-one`    | Conversation ID, matched member display name                              | Search diagnostics                                                               |
-| `find-people`        | Display name, email, MRI, object ID (if present)                          | Optional profile attributes                                                      |
-| `find-chats`         | Thread ID, thread type, member count, match-relevant members              | Full member roster                                                               |
-| `get-messages`       | Message ID, sender, timestamp, message body, quoted message reference IDs | Reactions/followers/mentions as counts or compact lists; attachment internals    |
-| `send-message`       | Target conversation label, message ID, send/schedule timestamp            | Transport-level details                                                          |
-| `edit-message`       | Conversation label, message ID, edit timestamp                            | Transport-level details                                                          |
-| `delete-message`     | Conversation label, message ID                                            | Transport-level details                                                          |
-| `add-reaction`       | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                          |
-| `remove-reaction`    | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                          |
-| `get-members`        | Member ID, name, role, member type                                        | Non-actionable profile enrichment                                                |
-| `whoami`             | Display name, region                                                      | Internal auth metadata                                                           |
-| `get-transcript`     | Meeting title and readable transcript content                             | Raw VTT structure unless `rawVtt` is requested                                   |
-| `download-file`      | File name, file type, size, content type, saved location                  | Binary payload internals in Markdown text (binary is returned in content blocks) |
+| Action               | Concise must include                                                      | Concise may summarize                                                          |
+| -------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `list-conversations` | Conversation ID, topic, thread type, last-message indicator               | Ancillary conversation metadata not needed for selecting a target conversation |
+| `find-conversation`  | Conversation ID, thread type, topic                                       | Optional timestamps/nullable fields                                            |
+| `find-one-on-one`    | Conversation ID, matched member display name                              | Search diagnostics                                                             |
+| `find-people`        | Display name, email, MRI, object ID (if present)                          | Optional profile attributes                                                    |
+| `find-chats`         | Thread ID, thread type, member count, match-relevant members              | Full member roster                                                             |
+| `get-messages`       | Message ID, sender, timestamp, message body, quoted message reference IDs | Reactions/followers/mentions as counts or compact lists; attachment internals  |
+| `send-message`       | Target conversation label, message ID, send/schedule timestamp            | Transport-level details                                                        |
+| `edit-message`       | Conversation label, message ID, edit timestamp                            | Transport-level details                                                        |
+| `delete-message`     | Conversation label, message ID                                            | Transport-level details                                                        |
+| `add-reaction`       | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                        |
+| `remove-reaction`    | Conversation label, message ID, resolved reaction key                     | Transport-level details                                                        |
+| `get-members`        | Member ID, name, role, member type                                        | Non-actionable profile enrichment                                              |
+| `whoami`             | Display name, region                                                      | Internal auth metadata                                                         |
+| `get-transcript`     | Meeting title and readable transcript content                             | Raw VTT structure unless `rawVtt` is requested                                 |
+| `download-file`      | File name, file type, size, content type, saved location                  | Text and image payload internals; other binary files are returned by path only |
 
 This design follows [Anthropic's tool design guidance](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/best-practices) — a `response_format` enum with concise (~1/3 tokens) and detailed (full data) modes.
 
@@ -279,3 +279,16 @@ Each record contains: tool name, format, full input parameters, raw API result, 
 **This is internal tooling only.** It is not mentioned in the user-facing README and should not be presented as a feature to end users. The telemetry file grows unboundedly — clear it manually with `> /path/to/telemetry.jsonl` when no longer needed.
 
 To enable for your local MCP server in VS Code, add `"TEAMS_TELEMETRY": "true"` to the `env` block of the `teams` server in your MCP config.
+
+## Known limitations
+
+### File attachments with remote AI hosts
+
+`teams-api` runs as a **local** MCP server on the user's machine. Local MCP clients (Claude Desktop, Cursor, VS Code, Claude Code) share the same filesystem, so `--file` / `--image` paths and downloaded files all resolve normally.
+
+Cloud-hosted AI clients (e.g. Claude.ai) run in isolated containers on remote infrastructure. This creates two problems:
+
+- **Sending files fails.** The AI generates paths inside its own container (e.g. `/tmp/report.md`). Those paths don't exist on the user's machine where the MCP server runs, so `open()` throws `ENOENT`.
+- **Downloading binary files is read-only.** The server saves files to the user's local disk successfully, but the remote AI can't access that path. Text content and images are returned inline in the MCP response so the AI can read them; other binary formats (PDFs, videos, archives) are saved locally only and cannot be round-tripped back to the remote container.
+
+This is a fundamental architectural mismatch between local MCP servers and cloud-hosted AI clients — the MCP protocol transports JSON only, with no file-transfer or shared-filesystem primitive. **Workaround: use a local MCP client or the CLI for any workflow involving file attachments.**

--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ The Teams Chat Service URL varies by region. Login-based and debug-session auth 
 
 ## Known limitations
 
+- **File attachments are not supported from remote AI hosts** (e.g. Claude.ai). The MCP server runs locally on your machine, so `--file` / `--image` paths must exist on your local filesystem. Cloud-hosted AI clients run in isolated containers and cannot access local paths. Use a local MCP client (Claude Desktop, Cursor, VS Code) or the CLI for file attachments.
 - Token lifetime is ~24 hours. After expiry, you must re-acquire.
 - The Teams Chat Service REST API is undocumented and may change without notice.
 - Auto-login requires macOS, system Chrome, a platform authenticator, and a FIDO2 passkey. On other platforms, use interactive login (`--login`) instead.

--- a/src/actions/file-actions.ts
+++ b/src/actions/file-actions.ts
@@ -34,7 +34,9 @@ export const downloadFileAction: ActionDefinition = {
     "Specify the message containing the file(s) via --message-id. " +
     "Use --output-directory to save files to a specific directory. " +
     "Without --output-directory, files are saved to a temporary directory. " +
-    "File contents are returned inline in the response.",
+    "Text file contents and images are returned inline in the response. " +
+    "Other binary files (PDFs, videos, archives, etc.) are saved to disk only; " +
+    "the response reports the local save path.",
   parameters: [
     ...conversationParameters,
     {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,6 +44,7 @@ import type { ActionParameter, OutputFormat } from "./actions/formatters.js";
 import type { DownloadResult } from "./actions/file-actions.js";
 import { serverInstructions } from "./server-instructions.js";
 import { recordToolCall, recordToolError } from "./telemetry.js";
+import { buildDownloadContentBlocks } from "./model-context-protocol-download-content.js";
 import {
   AuthenticationInProgressError,
   McpAuthManager,
@@ -118,111 +119,6 @@ const authManager = new McpAuthManager<TeamsClient>({
 });
 
 // ── Register all actions as MCP tools ─────────────────────────────────
-
-/** MIME types that are safe to return as inline text to the LLM. */
-const TEXT_MIME_PREFIXES = [
-  "text/",
-  "application/json",
-  "application/xml",
-  "application/javascript",
-  "application/typescript",
-  "application/x-yaml",
-  "application/yaml",
-  "application/toml",
-];
-
-/** File extensions that are known to be text-based. */
-const TEXT_FILE_EXTENSIONS = new Set([
-  "md",
-  "txt",
-  "csv",
-  "tsv",
-  "json",
-  "xml",
-  "yaml",
-  "yml",
-  "toml",
-  "html",
-  "htm",
-  "css",
-  "js",
-  "ts",
-  "jsx",
-  "tsx",
-  "py",
-  "rb",
-  "sh",
-  "bash",
-  "zsh",
-  "ps1",
-  "bat",
-  "cmd",
-  "sql",
-  "graphql",
-  "svg",
-  "log",
-  "ini",
-  "cfg",
-  "conf",
-  "env",
-  "properties",
-]);
-
-function isTextContent(mimeType: string, fileName: string): boolean {
-  const lowerMime = mimeType.toLowerCase();
-  if (TEXT_MIME_PREFIXES.some((prefix) => lowerMime.startsWith(prefix))) {
-    return true;
-  }
-  // Fall back to file extension when MIME type is generic (e.g. application/octet-stream)
-  const extension = fileName.includes(".")
-    ? fileName.split(".").pop()?.toLowerCase()
-    : undefined;
-  return extension !== undefined && TEXT_FILE_EXTENSIONS.has(extension);
-}
-
-/**
- * Build MCP content blocks for file download results.
- *
- * Returns the file content inline so the LLM can read it directly:
- * - Text files → EmbeddedResource with text content
- * - Images → ImageContent with base64 data
- * - Other binary → EmbeddedResource with base64 blob
- */
-function buildDownloadContentBlocks(
-  downloads: DownloadResult[],
-): ContentBlock[] {
-  const blocks: ContentBlock[] = [];
-  for (const download of downloads) {
-    const fileUri = `file://${download.savedTo}`;
-
-    if (download.contentType.startsWith("image/")) {
-      blocks.push({
-        type: "image" as const,
-        data: download.data.toString("base64"),
-        mimeType: download.contentType,
-      });
-    } else if (isTextContent(download.contentType, download.fileName)) {
-      blocks.push({
-        type: "resource" as const,
-        resource: {
-          uri: fileUri,
-          mimeType: download.contentType,
-          text: download.data.toString("utf-8"),
-        },
-      });
-    } else {
-      blocks.push({
-        type: "resource" as const,
-        resource: {
-          uri: fileUri,
-          mimeType: download.contentType,
-          blob: download.data.toString("base64"),
-        },
-      });
-    }
-  }
-  return blocks;
-}
 
 for (const action of actions) {
   const toolName = `teams_${action.name.replace(/-/g, "_")}`;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,7 +44,10 @@ import type { ActionParameter, OutputFormat } from "./actions/formatters.js";
 import type { DownloadResult } from "./actions/file-actions.js";
 import { serverInstructions } from "./server-instructions.js";
 import { recordToolCall, recordToolError } from "./telemetry.js";
-import { buildDownloadContentBlocks } from "./model-context-protocol-download-content.js";
+import {
+  buildDownloadContentBlocks,
+  createDownloadOutputResults,
+} from "./model-context-protocol-download-content.js";
 import {
   AuthenticationInProgressError,
   McpAuthManager,
@@ -163,24 +166,18 @@ for (const action of actions) {
           parameters as Record<string, unknown>,
         );
 
-        const output = formatOutput(action, result, outputFormat);
-        const durationMs = Date.now() - start;
-
-        // Redact binary data before recording telemetry — Buffer serialises as
-        // a large numeric array and would massively bloat telemetry.jsonl.
-        const telemetryResult =
+        const outputResult =
           action.name === "download-file" && Array.isArray(result)
-            ? (result as DownloadResult[]).map(({ data, ...rest }) => ({
-                ...rest,
-                byteLength: data.byteLength,
-              }))
+            ? createDownloadOutputResults(result as DownloadResult[])
             : result;
+        const output = formatOutput(action, outputResult, outputFormat);
+        const durationMs = Date.now() - start;
 
         recordToolCall({
           tool: action.name,
           format: outputFormat,
           parameters: parameters as Record<string, unknown>,
-          result: telemetryResult,
+          result: outputResult,
           output,
           durationMs,
         });

--- a/src/model-context-protocol-download-content.ts
+++ b/src/model-context-protocol-download-content.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import type { DownloadResult } from "./actions/file-actions.js";
 
@@ -65,7 +66,7 @@ export function buildDownloadContentBlocks(
 ): ContentBlock[] {
   const contentBlocks: ContentBlock[] = [];
   for (const download of downloads) {
-    if (download.contentType.startsWith("image/")) {
+    if (download.contentType.toLowerCase().startsWith("image/")) {
       contentBlocks.push({
         type: "image" as const,
         data: download.data.toString("base64"),
@@ -75,7 +76,7 @@ export function buildDownloadContentBlocks(
       contentBlocks.push({
         type: "resource" as const,
         resource: {
-          uri: `file://${download.savedTo}`,
+          uri: pathToFileURL(download.savedTo).toString(),
           mimeType: download.contentType,
           text: download.data.toString("utf-8"),
         },
@@ -83,4 +84,13 @@ export function buildDownloadContentBlocks(
     }
   }
   return contentBlocks;
+}
+
+export function createDownloadOutputResults(
+  downloads: DownloadResult[],
+): Array<Omit<DownloadResult, "data"> & { byteLength: number }> {
+  return downloads.map(({ data, ...download }) => ({
+    ...download,
+    byteLength: data.byteLength,
+  }));
 }

--- a/src/model-context-protocol-download-content.ts
+++ b/src/model-context-protocol-download-content.ts
@@ -1,0 +1,86 @@
+import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import type { DownloadResult } from "./actions/file-actions.js";
+
+const TEXT_MIME_PREFIXES = [
+  "text/",
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/typescript",
+  "application/x-yaml",
+  "application/yaml",
+  "application/toml",
+];
+
+const TEXT_FILE_EXTENSIONS = new Set([
+  "md",
+  "txt",
+  "csv",
+  "tsv",
+  "json",
+  "xml",
+  "yaml",
+  "yml",
+  "toml",
+  "html",
+  "htm",
+  "css",
+  "js",
+  "ts",
+  "jsx",
+  "tsx",
+  "py",
+  "rb",
+  "sh",
+  "bash",
+  "zsh",
+  "ps1",
+  "bat",
+  "cmd",
+  "sql",
+  "graphql",
+  "svg",
+  "log",
+  "ini",
+  "cfg",
+  "conf",
+  "env",
+  "properties",
+]);
+
+function isTextContent(mimeType: string, fileName: string): boolean {
+  const lowerMimeType = mimeType.toLowerCase();
+  if (TEXT_MIME_PREFIXES.some((prefix) => lowerMimeType.startsWith(prefix))) {
+    return true;
+  }
+
+  const extension = fileName.includes(".")
+    ? fileName.split(".").pop()?.toLowerCase()
+    : undefined;
+  return extension !== undefined && TEXT_FILE_EXTENSIONS.has(extension);
+}
+
+export function buildDownloadContentBlocks(
+  downloads: DownloadResult[],
+): ContentBlock[] {
+  const contentBlocks: ContentBlock[] = [];
+  for (const download of downloads) {
+    if (download.contentType.startsWith("image/")) {
+      contentBlocks.push({
+        type: "image" as const,
+        data: download.data.toString("base64"),
+        mimeType: download.contentType,
+      });
+    } else if (isTextContent(download.contentType, download.fileName)) {
+      contentBlocks.push({
+        type: "resource" as const,
+        resource: {
+          uri: `file://${download.savedTo}`,
+          mimeType: download.contentType,
+          text: download.data.toString("utf-8"),
+        },
+      });
+    }
+  }
+  return contentBlocks;
+}

--- a/tests/unit/model-context-protocol-download-content.test.ts
+++ b/tests/unit/model-context-protocol-download-content.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { DownloadResult } from "../../src/actions/file-actions.js";
+import { buildDownloadContentBlocks } from "../../src/model-context-protocol-download-content.js";
+
+function createDownloadResult(
+  overrides: Partial<DownloadResult> = {},
+): DownloadResult {
+  return {
+    fileName: "report.pdf",
+    fileType: "pdf",
+    size: 4,
+    contentType: "application/pdf",
+    savedTo: "/downloads/report.pdf",
+    data: Buffer.from("data"),
+    ...overrides,
+  };
+}
+
+describe("buildDownloadContentBlocks", () => {
+  it("returns image data inline", () => {
+    const imageData = Buffer.from("image data");
+
+    expect(
+      buildDownloadContentBlocks([
+        createDownloadResult({
+          fileName: "photo.png",
+          fileType: "png",
+          contentType: "image/png",
+          savedTo: "/downloads/photo.png",
+          data: imageData,
+        }),
+      ]),
+    ).toEqual([
+      {
+        type: "image",
+        data: imageData.toString("base64"),
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
+  it("returns text file content inline", () => {
+    expect(
+      buildDownloadContentBlocks([
+        createDownloadResult({
+          fileName: "notes.txt",
+          fileType: "txt",
+          contentType: "text/plain",
+          savedTo: "/downloads/notes.txt",
+          data: Buffer.from("meeting notes"),
+        }),
+      ]),
+    ).toEqual([
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///downloads/notes.txt",
+          mimeType: "text/plain",
+          text: "meeting notes",
+        },
+      },
+    ]);
+  });
+
+  it("recognizes text content by extension when the MIME type is generic", () => {
+    expect(
+      buildDownloadContentBlocks([
+        createDownloadResult({
+          fileName: "config.yaml",
+          fileType: "yaml",
+          contentType: "application/octet-stream",
+          savedTo: "/downloads/config.yaml",
+          data: Buffer.from("enabled: true"),
+        }),
+      ]),
+    ).toEqual([
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///downloads/config.yaml",
+          mimeType: "application/octet-stream",
+          text: "enabled: true",
+        },
+      },
+    ]);
+  });
+
+  it("omits non-image binary content", () => {
+    expect(buildDownloadContentBlocks([createDownloadResult()])).toEqual([]);
+  });
+});

--- a/tests/unit/model-context-protocol-download-content.test.ts
+++ b/tests/unit/model-context-protocol-download-content.test.ts
@@ -1,6 +1,11 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { DownloadResult } from "../../src/actions/file-actions.js";
-import { buildDownloadContentBlocks } from "../../src/model-context-protocol-download-content.js";
+import {
+  buildDownloadContentBlocks,
+  createDownloadOutputResults,
+} from "../../src/model-context-protocol-download-content.js";
 
 function createDownloadResult(
   overrides: Partial<DownloadResult> = {},
@@ -39,14 +44,38 @@ describe("buildDownloadContentBlocks", () => {
     ]);
   });
 
+  it("recognizes image MIME types case-insensitively", () => {
+    const imageData = Buffer.from("image data");
+
+    expect(
+      buildDownloadContentBlocks([
+        createDownloadResult({
+          fileName: "photo.png",
+          fileType: "png",
+          contentType: "Image/PNG",
+          savedTo: "/downloads/photo.png",
+          data: imageData,
+        }),
+      ]),
+    ).toEqual([
+      {
+        type: "image",
+        data: imageData.toString("base64"),
+        mimeType: "Image/PNG",
+      },
+    ]);
+  });
+
   it("returns text file content inline", () => {
+    const savedTo = resolve("/downloads/meeting notes#review.txt");
+
     expect(
       buildDownloadContentBlocks([
         createDownloadResult({
           fileName: "notes.txt",
           fileType: "txt",
           contentType: "text/plain",
-          savedTo: "/downloads/notes.txt",
+          savedTo,
           data: Buffer.from("meeting notes"),
         }),
       ]),
@@ -54,7 +83,7 @@ describe("buildDownloadContentBlocks", () => {
       {
         type: "resource",
         resource: {
-          uri: "file:///downloads/notes.txt",
+          uri: pathToFileURL(savedTo).toString(),
           mimeType: "text/plain",
           text: "meeting notes",
         },
@@ -87,5 +116,18 @@ describe("buildDownloadContentBlocks", () => {
 
   it("omits non-image binary content", () => {
     expect(buildDownloadContentBlocks([createDownloadResult()])).toEqual([]);
+  });
+
+  it("removes binary data from detailed download output", () => {
+    expect(createDownloadOutputResults([createDownloadResult()])).toEqual([
+      {
+        fileName: "report.pdf",
+        fileType: "pdf",
+        size: 4,
+        contentType: "application/pdf",
+        savedTo: "/downloads/report.pdf",
+        byteLength: 4,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Ⓜ

## Summary

Avoid returning raw base64 for non-image binary downloads through MCP when the model cannot use that content directly.

- Continue returning images as inline image content.
- Continue returning text files as inline resources, including text recognized by file extension when the MIME type is generic.
- Save PDFs, videos, archives, and other binary files locally and report their path without embedding a token-heavy base64 blob.
- Extract the pure MCP content conversion into a testable module.
- Document the local-filesystem limitation for remote AI hosts and align the contributor output contract.

## Validation

- `npm test`: 700 passed, 41 skipped
- `npm run type-check`
- `npm run build`
- `npm run format-check`
- Direct regression coverage for image, MIME-based text, extension-based text, and non-image binary responses.