### PR TITLE
Recognize attributed conventional commits in releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
+        "parserOpts": {
+          "headerPattern": "^(?:Ⓜ )?(\\w*)(?:\\((.*)\\))?!?: (.*)$",
+          "breakingHeaderPattern": "^(?:Ⓜ )?(\\w*)(?:\\((.*)\\))?!: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"]
+        },
         "releaseRules": [
+          { "breaking": true, "release": "major" },
           { "type": "build", "release": "patch" },
           { "type": "chore", "release": "patch" },
           { "type": "ci", "release": "patch" },
@@ -20,7 +26,16 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "parserOpts": {
+          "headerPattern": "^(?:Ⓜ )?(\\w*)(?:\\((.*)\\))?!?: (.*)$",
+          "breakingHeaderPattern": "^(?:Ⓜ )?(\\w*)(?:\\((.*)\\))?!: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"]
+        }
+      }
+    ],
     [
       "@semantic-release/changelog",
       {
@@ -39,7 +54,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "Ⓜ chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
Ⓜ Fix semantic-release parsing so required attribution-prefixed conventional commits drive version analysis and release notes. Preserve unprefixed commit support, breaking-change precedence, and attribution on generated release commits.